### PR TITLE
fix: restore ARM/v6 support and update Dockerfile to use Node.js 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,11 +155,11 @@ jobs:
           # - linux/amd64:    Standard x86_64 servers and desktops
           # - linux/arm64:    Apple Silicon, AWS Graviton, Raspberry Pi 4/5
           # - linux/arm/v7:   Raspberry Pi 3, older 32-bit ARM devices
-          # Note: ARM/v6 (Pi Zero/1) not supported - Node.js 24 dropped ARM/v6 support
+          # - linux/arm/v6:   Raspberry Pi Zero/1, lightweight IoT devices
           # Note: GHCR shows an additional "unknown/unknown" entry - this is the SLSA
           # attestation manifest (provenance + SBOM metadata), not a runnable image.
           # This is expected OCI behavior and required for supply chain security.
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           push: true
           target: production
           tags: ${{ steps.meta.outputs.tags }}
@@ -226,7 +226,7 @@ jobs:
           
           **Tags:** \`latest\` \`${VERSION}\` \`${MINOR}\` \`${MAJOR}\`
           
-          **Platforms:** \`amd64\` \`arm64\` \`arm/v7\`
+          **Platforms:** \`amd64\` \`arm64\` \`arm/v7\` \`arm/v6\`
           
           <details>
           <summary>Verify image signature</summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ New Features
 
-- **Node.js 24 Alpine**: Upgraded base image from `node:22-alpine` to `node:24-alpine`
-  - Latest LTS with improved performance and security
-  - ARM/v6 (Pi Zero/1) support dropped due to Node.js 24 platform requirements
+- **ARM/v6 Support**: Added 32-bit ARMv6 architecture (Raspberry Pi Zero/1)
+  - Docker images now available for: `linux/amd64`, `linux/arm64`, `linux/arm/v7`, `linux/arm/v6`
 
 ### 📦 Improvements
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG VERSION=unknown
 ARG BUILD_DATE=unknown
 ARG COMMIT_SHA=unknown
 
-FROM node:24-alpine AS builder
+FROM node:22-alpine AS builder
 
 # Upgrade OS packages and install build dependencies
 # python3, make, g++ are required for native Node.js modules (e.g., on ARM)
@@ -59,7 +59,7 @@ RUN npm prune --omit=dev && npm cache clean --force
 # =============================================================================
 
 # Used for local development with hot-reload and debugging capabilities
-FROM node:24-alpine AS development
+FROM node:22-alpine AS development
 
 # Upgrade OS packages and install development tools
 RUN apk upgrade --no-cache && apk add --no-cache git zsh curl
@@ -95,7 +95,7 @@ CMD ["npm", "run", "dev"]
 # Production stage
 # =============================================================================
 
-FROM node:24-alpine AS production
+FROM node:22-alpine AS production
 
 # Re-declare ARGs for this stage (needed for LABELs)
 ARG VERSION


### PR DESCRIPTION
Revert docker base image from node-24 to node-22 to hold the support for arm/v7 and arm/v6 arch.