### PR TITLE
Fix terminal exec rejection cleanup

### DIFF
--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -191,8 +191,13 @@ function collectCallbackOutput(
       buf.markTimeout();
       resolve(buf.getResult());
     }, TERMINAL_TIMEOUT_MS);
-    // Clean up timer when exec finishes first to avoid leaking
-    void execPromise.then(() => clearTimeout(timer));
+    // Clean up timer when exec finishes first to avoid leaking.
+    // Handle rejection here too so the cleanup promise cannot become an
+    // unhandled rejection while the original execPromise is handled by race().
+    void execPromise.then(
+      () => clearTimeout(timer),
+      () => clearTimeout(timer),
+    );
   });
 
   return Promise.race([execPromise, timeoutPromise]);


### PR DESCRIPTION
## Summary

Fix an unhandled rejection in terminal output collection.

`collectCallbackOutput` starts one timeout timer, then runs the Komodo terminal execution promise in parallel with that timer. If terminal execution finishes first, the timer should be cleared.

Previously, the cleanup handler only covered the success case:

```ts
void execPromise.then(() => clearTimeout(timer));
```

If `execPromise` rejected, for example because the Komodo user lacked `Terminal` permission, that cleanup `.then(...)` created a second rejected promise chain with no rejection handler. Even though the original execution error was handled by `Promise.race`, this cleanup chain could still produce an unhandled rejection and restart the MCP server.

This change keeps the same single timer, but clears it whether execution succeeds or fails:

```ts
void execPromise.then(
  () => clearTimeout(timer),
  () => clearTimeout(timer),
);
```

The runtime behavior is unchanged for callers: successful terminal calls still return output, failed terminal calls still return the original error, and timed-out terminal calls still return the timeout result. The difference is that rejected terminal calls no longer create an extra unhandled rejection through the cleanup path.

## Validation

- `npm run typecheck`
- `npm run lint`
- Built and deployed the patched server from `puigru/komodo-mcp-server#codex/fix-terminal-exec-rejection`
- Triggered a denied terminal call against a server without `Terminal` permission
- Confirmed the call returned the expected permission error and the MCP server remained healthy afterward