### PR TITLE
fix(security): redact secret values in tool output

### DIFF
--- a/src/tools/stack.ts
+++ b/src/tools/stack.ts
@@ -198,7 +198,9 @@ export const deleteStackTool = defineTool({
       () => komodo.client.write("DeleteStack", { id: args.stack }),
       abortSignal,
     );
-    const built = buildDeleteResult("stack", args.stack, result);
+    // The deleted-resource snapshot carries the post-interpolation
+    // deployed_config/deployed_contents — strip them before the transcript.
+    const built = buildDeleteResult("stack", args.stack, redactDeployedSecrets(result));
     return structured(built.payload, { text: built.text });
   },
 });

--- a/src/tools/stack.ts
+++ b/src/tools/stack.ts
@@ -47,6 +47,27 @@ import {
 type StackListItem = Types.StackListItem;
 
 // ============================================================================
+// Secret Redaction
+// ============================================================================
+
+/**
+ * Strip the post-interpolation deploy artifacts from a stack before returning it.
+ *
+ * `deployed_config` (the `docker compose config` output) and `deployed_contents`
+ * carry `[[variable.x]]` references already expanded to their real values, so a
+ * secret interpolated into a compose file or clone URL would otherwise surface
+ * in the tool result — and from there into the client transcript and model
+ * provider. The source config (`file_contents`, `environment`) is retained.
+ */
+function redactDeployedSecrets(stack: Types.Stack): Types.Stack {
+  if (!stack.info) return stack;
+  const info = { ...stack.info };
+  delete info.deployed_config;
+  delete info.deployed_contents;
+  return { ...stack, info };
+}
+
+// ============================================================================
 // List
 // ============================================================================
 
@@ -92,10 +113,8 @@ export const getStackInfoTool = defineTool({
   requiredScopes: [ToolScopes.READ],
   handler: async (args, { abortSignal, sessionId }) => {
     const komodo = requireClient();
-    const result = await wrapApiCall(
-      "getStackInfo",
-      () => komodo.client.read("GetStack", { stack: args.stack }),
-      abortSignal,
+    const result = redactDeployedSecrets(
+      await wrapApiCall("getStackInfo", () => komodo.client.read("GetStack", { stack: args.stack }), abortSignal),
     );
     const link = tryRegisterResource({
       ctx: { sessionId },
@@ -141,7 +160,7 @@ export const applyStackTool = defineTool({
         () => komodo.client.write("CreateStack", { name, config: stackConfig }),
         abortSignal,
       );
-      const built = buildApplyResult("create", "stack", name, result);
+      const built = buildApplyResult("create", "stack", name, redactDeployedSecrets(result));
       return structured(built.payload, { text: built.text });
     }
     if (!args.stack) throw AppErrorFactory.validation.fieldRequired("stack");
@@ -156,7 +175,7 @@ export const applyStackTool = defineTool({
         }),
       abortSignal,
     );
-    const built = buildApplyResult("update", "stack", stackId, result);
+    const built = buildApplyResult("update", "stack", stackId, redactDeployedSecrets(result));
     return structured(built.payload, { text: built.text });
   },
 });

--- a/src/tools/variable.ts
+++ b/src/tools/variable.ts
@@ -59,6 +59,15 @@ function projectVariable(v: Variable): {
   };
 }
 
+/**
+ * Mask a secret variable's value in the full resource returned by the write and
+ * delete tools — unlike reads, write responses echo the plaintext value even for
+ * `is_secret` variables. Passes non-secrets (and `undefined`) through.
+ */
+function maskSecretValue(v: Variable | undefined): Variable | undefined {
+  return v?.is_secret ? { ...v, value: SECRET_PLACEHOLDER } : v;
+}
+
 // ============================================================================
 // List
 // ============================================================================
@@ -138,7 +147,7 @@ export const applyVariableTool = defineTool({
         () => komodo.client.write("CreateVariable", params),
         abortSignal,
       );
-      const built = buildApplyResult("create", "variable", args.name, result);
+      const built = buildApplyResult("create", "variable", args.name, maskSecretValue(result));
       return structured(built.payload, { text: built.text });
     }
     // update — dispatch to one or more endpoints based on which fields are set
@@ -170,7 +179,7 @@ export const applyVariableTool = defineTool({
         abortSignal,
       );
     }
-    const built = buildApplyResult("update", "variable", args.name, updated);
+    const built = buildApplyResult("update", "variable", args.name, maskSecretValue(updated));
     return structured(built.payload, { text: built.text });
   },
 });
@@ -195,8 +204,7 @@ export const deleteVariableTool = defineTool({
     );
     // The deleted-resource snapshot echoes the variable verbatim — redact a
     // secret value before it reaches the client transcript.
-    const safe = result.is_secret ? { ...result, value: SECRET_PLACEHOLDER } : result;
-    const built = buildDeleteResult("variable", args.name, safe);
+    const built = buildDeleteResult("variable", args.name, maskSecretValue(result));
     return structured(built.payload, { text: built.text });
   },
 });

--- a/src/tools/variable.ts
+++ b/src/tools/variable.ts
@@ -39,6 +39,9 @@ import {
 
 type Variable = Types.Variable;
 
+/** Placeholder substituted for secret variable values in tool output. */
+const SECRET_PLACEHOLDER = "[redacted]";
+
 function projectVariable(v: Variable): {
   name: string;
   value: string;
@@ -47,7 +50,10 @@ function projectVariable(v: Variable): {
 } {
   return {
     name: v.name,
-    value: v.value ?? "",
+    // Never surface a secret's value: MCP results are persisted to the client
+    // transcript (and sent to the model provider), so redact regardless of the
+    // caller's Komodo scope — core only redacts for non-admin keys.
+    value: v.is_secret ? SECRET_PLACEHOLDER : (v.value ?? ""),
     ...(v.description !== undefined && v.description !== "" ? { description: v.description } : {}),
     ...(v.is_secret ? { is_secret: true } : {}),
   };
@@ -187,7 +193,10 @@ export const deleteVariableTool = defineTool({
       () => komodo.client.write("DeleteVariable", { name: args.name }),
       abortSignal,
     );
-    const built = buildDeleteResult("variable", args.name, result);
+    // The deleted-resource snapshot echoes the variable verbatim — redact a
+    // secret value before it reaches the client transcript.
+    const safe = result.is_secret ? { ...result, value: SECRET_PLACEHOLDER } : result;
+    const built = buildDeleteResult("variable", args.name, safe);
     return structured(built.payload, { text: built.text });
   },
 });


### PR DESCRIPTION
MCP tool results are persisted to the client transcript and sent to the model provider, so any secret returned in a result leaks outside Komodo's secret-handling boundary. Exploitation requires an admin-scoped API key (so this is information disclosure into the operator's own transcript / model provider, not a remote-attacker primitive), but it silently undoes Komodo's `is_secret` redaction.

- **`variable_list` / `info` / `delete`**: redact a variable's `value` to `***` when `is_secret`. The MCP layer relied on Komodo core redaction, which only applies to non-admin keys — an admin-scoped key received the real value.
- **`stack_info` / `apply`**: drop the post-interpolation `deployed_config` (the `docker compose config` output) and `deployed_contents`, which carry `[[variable.x]]` references already expanded to their real values (e.g. a token embedded in a repo clone URL). Source `file_contents` / `environment` are retained.

**Behaviour change (flagging for your call):** `stack_info` / `apply` no longer return the resolved deploy artifacts. If you'd prefer to keep them behind an opt-in flag, or mask-by-value instead, happy to adjust.

_AI-assisted (Claude Opus 4.8), human-reviewed._