### PR TITLE
fix(action,procedure): accept null for last_run_at and next_scheduled_run

### DIFF
--- a/src/tools/action.ts
+++ b/src/tools/action.ts
@@ -73,8 +73,8 @@ export const listActionsTool = defineTool({
       id: a.id,
       name: a.name,
       state: a.info.state,
-      ...(a.info.last_run_at !== undefined ? { last_run_at: a.info.last_run_at } : {}),
-      ...(a.info.next_scheduled_run !== undefined ? { next_scheduled_run: a.info.next_scheduled_run } : {}),
+      ...(a.info.last_run_at != null ? { last_run_at: a.info.last_run_at } : {}),
+      ...(a.info.next_scheduled_run != null ? { next_scheduled_run: a.info.next_scheduled_run } : {}),
       ...(a.info.schedule_error ? { schedule_error: a.info.schedule_error } : {}),
     }));
 

--- a/src/tools/procedure.ts
+++ b/src/tools/procedure.ts
@@ -68,8 +68,8 @@ export const listProceduresTool = defineTool({
       name: p.name,
       state: p.info.state,
       stages: p.info.stages,
-      ...(p.info.last_run_at !== undefined ? { last_run_at: p.info.last_run_at } : {}),
-      ...(p.info.next_scheduled_run !== undefined ? { next_scheduled_run: p.info.next_scheduled_run } : {}),
+      ...(p.info.last_run_at != null ? { last_run_at: p.info.last_run_at } : {}),
+      ...(p.info.next_scheduled_run != null ? { next_scheduled_run: p.info.next_scheduled_run } : {}),
       ...(p.info.schedule_error ? { schedule_error: p.info.schedule_error } : {}),
     }));
 

--- a/src/tools/schemas/action.ts
+++ b/src/tools/schemas/action.ts
@@ -26,8 +26,8 @@ export const actionSummarySchema = z.object({
   id: z.string().describe("Action ID"),
   name: z.string().describe("Action name"),
   state: z.string().optional().describe("Action state (Running, Ok, Failed, Unknown) when known"),
-  last_run_at: z.number().int().optional().describe("Unix timestamp (ms) of the last successful run"),
-  next_scheduled_run: z.number().int().optional().describe("Unix timestamp (ms) of the next scheduled run"),
+  last_run_at: z.number().int().nullable().optional().describe("Unix timestamp (ms) of the last successful run"),
+  next_scheduled_run: z.number().int().nullable().optional().describe("Unix timestamp (ms) of the next scheduled run"),
   schedule_error: z.string().optional().describe("Error parsing the schedule expression, if any"),
 });
 

--- a/src/tools/schemas/procedure.ts
+++ b/src/tools/schemas/procedure.ts
@@ -23,8 +23,8 @@ export const procedureSummarySchema = z.object({
   name: z.string().describe("Procedure name"),
   state: z.string().optional().describe("Procedure state (Running, Ok, Failed, Unknown) when known"),
   stages: z.number().int().optional().describe("Number of stages this procedure has"),
-  last_run_at: z.number().int().optional().describe("Unix timestamp (ms) of the last successful run"),
-  next_scheduled_run: z.number().int().optional().describe("Unix timestamp (ms) of the next scheduled run"),
+  last_run_at: z.number().int().nullable().optional().describe("Unix timestamp (ms) of the last successful run"),
+  next_scheduled_run: z.number().int().nullable().optional().describe("Unix timestamp (ms) of the next scheduled run"),
   schedule_error: z.string().optional().describe("Error parsing the schedule expression, if any"),
 });
 


### PR DESCRIPTION
## bug

Komodo-core returns `null` (not `undefined`) for `last_run_at` and `next_scheduled_run` on actions/procedures that have not yet run or have no schedule configured. The current Zod schema only accepts `number | undefined` via `.optional()`, so the validation step rejects every list response with:

```
Output validation error: ... next_scheduled_run:
 Expected number, received null
```

This blocked `komodo_action_list` (and would block `komodo_procedure_list` once any unscheduled procedure exists).

## fix

Two-part change:

- **schema**: extend `.optional()` with `.nullable()` so both `null` and `undefined` pass validation (covers `last_run_at` and `next_scheduled_run` on both action + procedure summary schemas)
- **wrapper**: switch `!== undefined` to `!= null` in the list handlers so the output object omits the field entirely when there's no data, rather than emitting a `null` key

## verification

Built locally, deployed alongside `komodo-core v2.2.0`. Before: `komodo_action_list` returned 0 actions with a Zod validation error. After: returns all 6 actions cleanly, with fields omitted from output when no schedule/last-run data exists.
