### PR TITLE
fix(security): redact secret env values in container_inspect and deployment_info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ yarn-error.log*
 
 # Production build
 build/
+build-test/
 dist/
 
 # Environment variables

--- a/config/README.md
+++ b/config/README.md
@@ -154,6 +154,31 @@ secrets:
 
 > **Note:** Docker secret `*_FILE` variables are only supported as environment variables, not in config files.
 
+### Secret Redaction
+
+Responses from `komodo_deployment_info` and `komodo_container_inspect` are
+scrubbed of secret-looking environment values before they reach the MCP client,
+so secrets are less likely to end up in an assistant's context.
+
+| Variable | Config Key | Default | Description |
+|----------|-----------|---------|-------------|
+| `KOMODO_SECRET_SCRUB_ENABLED` | — | `true` | Master switch for redaction |
+| `KOMODO_SECRET_SCRUB_KEYWORDS` | — | (built-in list) | Override keyword tokens (comma-separated) |
+| `KOMODO_SECRET_SCRUB_KEYS` | — | — | Explicit key names always redacted |
+
+**Detection is two-pronged and best-effort:**
+
+- **Key-name:** an env key whose `_`-delimited tokens include a keyword
+  (default `KEY, SECRET, PASS, PASSWORD, PWD, TOKEN, CREDENTIAL, CREDENTIALS,
+  AUTH, PRIVATE`) or which is on `KOMODO_SECRET_SCRUB_KEYS`.
+- **Value-shape:** a value that looks like a credential regardless of key —
+  a URL with embedded `user:pass@`, a JWT, or a PEM private-key block.
+
+> **This is a heuristic, not a guarantee.** A secret with an innocuous key name
+> and an unremarkable value can still slip through. Add such keys to
+> `KOMODO_SECRET_SCRUB_KEYS`. Redaction does not cover `komodo_exec` output or
+> container logs.
+
 ## Transport & Network
 
 Controls how the MCP server communicates with clients.

--- a/config/example.config.env
+++ b/config/example.config.env
@@ -58,6 +58,22 @@ KOMODO_PASSWORD_FILE=/run/secrets/komodo_password
 ## Default: "30s" (30000ms)
 API_TIMEOUT_MS=30s
 
+## Secret redaction (best-effort) of API responses.
+## When enabled, secret-looking env values in deployment_info and
+## container_inspect responses are replaced with "[redacted]" before reaching
+## the MCP client. Heuristic, not a guarantee.
+## Default: true
+KOMODO_SECRET_SCRUB_ENABLED=true
+
+## Override the built-in secret keyword tokens (comma-separated, matched against
+## `_`-delimited key tokens, case-insensitive).
+## Built-in default: KEY,SECRET,PASS,PASSWORD,PWD,TOKEN,CREDENTIAL,CREDENTIALS,AUTH,PRIVATE
+# KOMODO_SECRET_SCRUB_KEYWORDS=KEY,SECRET,PASSWORD,TOKEN
+
+## Explicit key names to always redact even when they contain no keyword token
+## (e.g. DATABASE_URL, SESSION_ID). Comma-separated, case-insensitive.
+# KOMODO_SECRET_SCRUB_KEYS=DATABASE_URL,SESSION_ID
+
 
 ###################
 # MCP TRANSPORT   #

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,9 +7,12 @@ import eslintPluginPrettier from "eslint-plugin-prettier/recommended";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-  // Global ignores
+  // Global ignores. Test files are excluded from the base tsconfig project and
+  // use node:test patterns (bare `test(...)` calls) that the strict
+  // type-checked ruleset flags as floating promises — they are not part of the
+  // shipped build, so keep them out of lint.
   {
-    ignores: ["build/**", "node_modules/**", "**/*.js", "!eslint.config.js"],
+    ignores: ["build/**", "build-test/**", "node_modules/**", "**/*.js", "**/*.test.ts", "!eslint.config.js"],
   },
 
   // Base ESLint recommended rules

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "start": "node build/index.js",
     "dev": "npm run build && node build/index.js",
     "typecheck": "tsc --noEmit",
+    "test": "tsc -p tsconfig.test.json && node --test \"build-test/**/*.test.js\"",
     "clean": "rm -rf build coverage test-results *.tsbuildinfo",
     "clean:all": "rm -rf build node_modules coverage test-results *.tsbuildinfo",
     "lint": "eslint 'src/**/*.ts'",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -59,6 +59,34 @@ export const appEnvSchema = z.object({
 
   /** Maximum number of dynamic resource entries kept in memory. Default: 1000 */
   KOMODO_RESOURCE_MAX_ENTRIES: z.coerce.number().int().positive().default(1000),
+
+  /** Master switch for secret redaction of API responses. Accepts "true"/"false". Default: true */
+  KOMODO_SECRET_SCRUB_ENABLED: z
+    .enum(["true", "false"])
+    .default("true")
+    .transform((v) => v === "true"),
+
+  /** Comma-separated keyword tokens matched against env key tokens (uppercased). Overrides the built-in default list. */
+  KOMODO_SECRET_SCRUB_KEYWORDS: z
+    .string()
+    .transform((s) =>
+      s
+        .split(",")
+        .map((x) => x.trim().toUpperCase())
+        .filter(Boolean),
+    )
+    .optional(),
+
+  /** Comma-separated explicit key names always redacted (uppercased). */
+  KOMODO_SECRET_SCRUB_KEYS: z
+    .string()
+    .transform((s) =>
+      s
+        .split(",")
+        .map((x) => x.trim().toUpperCase())
+        .filter(Boolean),
+    )
+    .optional(),
 });
 
 export type AppEnvConfig = z.infer<typeof appEnvSchema>;

--- a/src/tools/container.ts
+++ b/src/tools/container.ts
@@ -38,6 +38,8 @@ import {
   renderContainerSearchLogs,
   renderActionResult,
   tryRegisterResource,
+  getRedactOptions,
+  redactEnvList,
 } from "../utils/index.js";
 import {
   containerActionInputSchema,
@@ -99,7 +101,8 @@ export const listContainersTool = defineTool({
 export const inspectContainerTool = defineTool({
   name: "komodo_container_inspect",
   description:
-    "Get detailed low-level information about a container. Returns Docker inspect data including configuration, state, network settings, mounts, and process info.",
+    "Get detailed low-level information about a container. Returns Docker inspect data including configuration, state, network settings, mounts, and process info. " +
+    "Secret-looking environment values are redacted (best-effort); disable with KOMODO_SECRET_SCRUB_ENABLED=false.",
   input: z
     .object({
       server: serverIdSchema.describe(PARAM_DESCRIPTIONS.SERVER_ID_WHERE_CONTAINER_RUNS),
@@ -117,6 +120,12 @@ export const inspectContainerTool = defineTool({
       () => komodo.client.read("InspectDockerContainer", { server: args.server, container: args.container }),
       abortSignal,
     );
+    // Docker inspect resolves [[variable]] references into plaintext env, so
+    // even correctly-configured Komodo Variables surface here — redact them.
+    const redactOpts = getRedactOptions();
+    if (result.Config?.Env) {
+      result.Config.Env = redactEnvList(result.Config.Env, redactOpts);
+    }
     const link = tryRegisterResource({
       ctx: { sessionId },
       category: "inspect",

--- a/src/tools/deployment.ts
+++ b/src/tools/deployment.ts
@@ -30,6 +30,8 @@ import {
   tryRegisterResource,
   buildApplyResult,
   buildDeleteResult,
+  getRedactOptions,
+  redactEnvBlock,
 } from "../utils/index.js";
 import {
   deploymentApplyInputSchema,
@@ -86,7 +88,8 @@ export const listDeploymentsTool = defineTool({
 export const getDeploymentInfoTool = defineTool({
   name: "komodo_deployment_info",
   description:
-    "Get detailed information about a Komodo-managed deployment, including its configuration, current state, and assigned server.",
+    "Get detailed information about a Komodo-managed deployment, including its configuration, current state, and assigned server. " +
+    "Secret-looking environment values are redacted (best-effort); disable with KOMODO_SECRET_SCRUB_ENABLED=false.",
   input: z
     .object({
       deployment: deploymentIdSchema.describe(PARAM_DESCRIPTIONS.DEPLOYMENT_ID_FOR_INFO),
@@ -103,6 +106,12 @@ export const getDeploymentInfoTool = defineTool({
       () => komodo.client.read("GetDeployment", { deployment: args.deployment }),
       abortSignal,
     );
+    // Redact secret env values before the result is stringified into a resource
+    // or placed in the payload (closes the resource-offload leak path).
+    const redactOpts = getRedactOptions();
+    if (result.config?.environment) {
+      result.config.environment = redactEnvBlock(result.config.environment, redactOpts);
+    }
     const link = tryRegisterResource({
       ctx: { sessionId },
       category: "info",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,6 +15,16 @@
 // --- API Helpers ---
 export { requireClient, checkCancelled, wrapApiCall } from "./api-helpers.js";
 
+// --- Secret Redaction (best-effort scrubbing of API responses) ---
+export {
+  REDACTED,
+  DEFAULT_SECRET_KEYWORDS,
+  getRedactOptions,
+  redactEnvBlock,
+  redactEnvList,
+  type RedactOptions,
+} from "./redact.js";
+
 // --- Resource Links (ephemeral session-bound payloads) ---
 export { tryRegisterResource } from "./resource-link.js";
 export type { ResourceCategory, ResourceLinkContext, RegisterResourceOptions } from "./resource-link.js";

--- a/src/utils/redact.test.ts
+++ b/src/utils/redact.test.ts
@@ -1,0 +1,87 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  REDACTED,
+  DEFAULT_SECRET_KEYWORDS,
+  shouldRedactKey,
+  shouldRedactValue,
+  redactKeyValueLine,
+  redactEnvBlock,
+  redactEnvList,
+  type RedactOptions,
+} from "./redact.js";
+
+const opts: RedactOptions = {
+  enabled: true,
+  keywords: DEFAULT_SECRET_KEYWORDS,
+  explicitKeys: [],
+};
+
+test("keyword token in key redacts value", () => {
+  assert.equal(redactKeyValueLine("API_KEY=abc123", opts), `API_KEY=${REDACTED}`);
+  assert.equal(redactKeyValueLine("DB_PASSWORD=hunter2", opts), `DB_PASSWORD=${REDACTED}`);
+  assert.equal(redactKeyValueLine("AUTH_TOKEN=xyz", opts), `AUTH_TOKEN=${REDACTED}`);
+});
+
+test("substring-only match on a key token does NOT redact", () => {
+  // MONKEY contains 'KEY' as a substring but is not the token 'KEY'.
+  assert.equal(redactKeyValueLine("MONKEY_NAME=jono", opts), "MONKEY_NAME=jono");
+});
+
+test("case-insensitive key matching", () => {
+  assert.equal(redactKeyValueLine("api_secret=zzz", opts), `api_secret=${REDACTED}`);
+});
+
+test("URL with embedded credentials masks only the credential portion", () => {
+  assert.equal(
+    redactKeyValueLine("DATABASE_URL=postgres://user:hunter2@db.host:5432/app", opts),
+    `DATABASE_URL=postgres://${REDACTED}@db.host:5432/app`,
+  );
+});
+
+test("JWT-shaped value under an innocuous key redacts fully", () => {
+  const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.abc-_123";
+  assert.equal(redactKeyValueLine(`GREETING=${jwt}`, opts), `GREETING=${REDACTED}`);
+});
+
+test("PEM private key block redacts fully", () => {
+  const pem = "-----BEGIN RSA PRIVATE KEY-----MIIEabc-----END RSA PRIVATE KEY-----";
+  assert.equal(redactKeyValueLine(`FOO=${pem}`, opts), `FOO=${REDACTED}`);
+});
+
+test("explicit key list redacts a keyword-free key", () => {
+  const explicit: RedactOptions = { ...opts, explicitKeys: ["DATABASE_URL", "SESSION_ID"] };
+  assert.equal(redactKeyValueLine("SESSION_ID=opaque123", explicit), `SESSION_ID=${REDACTED}`);
+});
+
+test("disabled options pass everything through", () => {
+  const off: RedactOptions = { ...opts, enabled: false };
+  assert.equal(redactKeyValueLine("API_KEY=abc", off), "API_KEY=abc");
+});
+
+test("non KEY=value lines are untouched", () => {
+  assert.equal(redactKeyValueLine("", opts), "");
+  assert.equal(redactKeyValueLine("# a comment", opts), "# a comment");
+  assert.equal(redactKeyValueLine("=leadingequals", opts), "=leadingequals");
+});
+
+test("empty value is left as-is", () => {
+  assert.equal(redactKeyValueLine("API_KEY=", opts), "API_KEY=");
+});
+
+test("shouldRedactKey / shouldRedactValue helpers", () => {
+  assert.equal(shouldRedactKey("SECRET_FOO", opts), true);
+  assert.equal(shouldRedactKey("PLAIN", opts), false);
+  assert.equal(shouldRedactValue("eyJa.eyJb.cc-_1"), true);
+  assert.equal(shouldRedactValue("just text"), false);
+});
+
+test("redactEnvBlock redacts a multi-line block, preserving order and non-secrets", () => {
+  const block = "HOST=localhost\nAPI_KEY=abc\nPORT=8080";
+  assert.equal(redactEnvBlock(block, opts), `HOST=localhost\nAPI_KEY=${REDACTED}\nPORT=8080`);
+});
+
+test("redactEnvList redacts a Docker-style env array", () => {
+  const list = ["PATH=/usr/bin", "TOKEN=deadbeef"];
+  assert.deepEqual(redactEnvList(list, opts), ["PATH=/usr/bin", `TOKEN=${REDACTED}`]);
+});

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,0 +1,112 @@
+/**
+ * Secret Redaction
+ *
+ * Best-effort redaction of secret values from Komodo API responses before they
+ * reach the MCP client (and therefore the model context). Two mechanisms:
+ *
+ *   - Key-name match: an env var whose name contains a secret keyword *token*
+ *     (KEY, SECRET, PASSWORD, ...) or is on the explicit key list.
+ *   - Value-shape match: a value that looks like a credential regardless of key
+ *     name (URL with embedded credentials, JWT, PEM private-key block).
+ *
+ * This is a heuristic, NOT a guarantee. A secret with an innocuous key name and
+ * an unremarkable value (e.g. a short opaque token) can still slip through.
+ * Komodo Variables marked `is_secret` are redacted separately and exactly.
+ *
+ * @module utils/redact
+ */
+
+import { config } from "../config/index.js";
+
+/** Placeholder substituted for a redacted value. Fixed — never encodes length. */
+export const REDACTED = "[redacted]";
+
+/** Default secret keyword tokens matched against `_`-delimited env key tokens. */
+export const DEFAULT_SECRET_KEYWORDS: readonly string[] = [
+  "KEY",
+  "SECRET",
+  "PASS",
+  "PASSWORD",
+  "PWD",
+  "TOKEN",
+  "CREDENTIAL",
+  "CREDENTIALS",
+  "AUTH",
+  "PRIVATE",
+];
+
+export interface RedactOptions {
+  /** Master switch. When false, all functions pass input through unchanged. */
+  readonly enabled: boolean;
+  /** Uppercase keyword tokens matched against key tokens. */
+  readonly keywords: readonly string[];
+  /** Uppercase explicit key names always redacted. */
+  readonly explicitKeys: readonly string[];
+}
+
+// Value-shape patterns — a deliberately small curated set. Entropy scoring is
+// intentionally omitted (highest false-positive lever, diminishing returns).
+
+const URL_WITH_CREDENTIALS = /^[a-z][a-z0-9+.-]*:\/\/[^/\s:@]+:[^/\s@]+@/i;
+const JWT = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/;
+// eslint-disable-next-line security/detect-unsafe-regex -- single optional group with a bounded literal suffix; no overlapping/nested quantifiers, so no ReDoS
+const PEM_PRIVATE_KEY = /-----BEGIN (?:[A-Z]+ )?PRIVATE KEY-----/;
+
+/** True if the env key name signals a secret (explicit list or keyword token). */
+export function shouldRedactKey(key: string, opts: RedactOptions): boolean {
+  const upper = key.toUpperCase();
+  if (opts.explicitKeys.includes(upper)) return true;
+  return upper.split("_").some((token) => opts.keywords.includes(token));
+}
+
+/** True if the value looks like a credential regardless of key name. */
+export function shouldRedactValue(value: string): boolean {
+  return URL_WITH_CREDENTIALS.test(value) || JWT.test(value) || PEM_PRIVATE_KEY.test(value);
+}
+
+/**
+ * Redact a single `KEY=value` line.
+ *
+ * Non-`KEY=value` lines (blank, comment, or no `=` / leading `=`) are returned
+ * unchanged. For URL-with-credentials values only the `user:pass@` portion is
+ * masked, so the scheme/host/path stay readable for debugging.
+ */
+export function redactKeyValueLine(line: string, opts: RedactOptions): string {
+  if (!opts.enabled) return line;
+  const eq = line.indexOf("=");
+  if (eq <= 0) return line;
+  const key = line.slice(0, eq);
+  const value = line.slice(eq + 1);
+  if (value === "") return line;
+  if (shouldRedactKey(key, opts)) return `${key}=${REDACTED}`;
+  if (URL_WITH_CREDENTIALS.test(value)) {
+    return `${key}=${value.replace(/(:\/\/)[^/\s:@]+:[^/\s@]+@/, `$1${REDACTED}@`)}`;
+  }
+  if (shouldRedactValue(value)) return `${key}=${REDACTED}`;
+  return line;
+}
+
+/** Redact a `\n`-joined env block (stack/deployment `config.environment`). */
+export function redactEnvBlock(block: string, opts: RedactOptions): string {
+  return block
+    .split("\n")
+    .map((line) => redactKeyValueLine(line, opts))
+    .join("\n");
+}
+
+/** Redact a `["KEY=value", ...]` array (Docker inspect `Config.Env`). */
+export function redactEnvList(list: readonly string[], opts: RedactOptions): string[] {
+  return list.map((line) => redactKeyValueLine(line, opts));
+}
+
+/**
+ * Build {@link RedactOptions} from parsed app config. Kept separate from the
+ * pure functions so those remain unit-testable without importing app config.
+ */
+export function getRedactOptions(): RedactOptions {
+  return {
+    enabled: config.KOMODO_SECRET_SCRUB_ENABLED,
+    keywords: config.KOMODO_SECRET_SCRUB_KEYWORDS ?? DEFAULT_SECRET_KEYWORDS,
+    explicitKeys: config.KOMODO_SECRET_SCRUB_KEYS ?? [],
+  };
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build-test",
+    "sourceMap": false,
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "build", "build-test"]
+}


### PR DESCRIPTION
Part of #160.

`komodo_container_inspect` returns the *resolved* container environment, so a secret stored correctly as a Komodo Variable still appears as plaintext in `Config.Env`. `komodo_deployment_info`'s `config.environment` can likewise carry inline secrets. Both are serialised into the tool result, which is persisted to the MCP transcript and forwarded to the model provider.

Adds a best-effort redaction pass before serialisation:
- **key-name** — env key whose `_`-delimited tokens include a keyword (`KEY`, `SECRET`, `TOKEN`, …) or a configured explicit key;
- **value-shape** — URL with embedded `user:pass@`, a JWT, or a PEM private-key block.

Gated behind `KOMODO_SECRET_SCRUB_ENABLED` (default on), with `KOMODO_SECRET_SCRUB_KEYWORDS` / `KOMODO_SECRET_SCRUB_KEYS` overrides. Heuristic, not a guarantee — documented as such.

`stack_info` has the same exposure in `config.environment`; left out here because it shares the handler #152 touches — will follow once #152 lands.

Ships `node:test` unit tests for the pure functions (the repo had no test setup — glad to reshape or drop that if you'd prefer). Verified against a live Komodo v2.

_AI-assisted (Claude Opus 4.8), human-reviewed._
