### PR TITLE
fix(security): centralise secret redaction across info/apply/delete tool output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ yarn-error.log*
 
 # Production build
 build/
+build-test/
 dist/
 
 # Environment variables

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Komodo MCP Server enables seamless interaction between AI assistants (like Claud
 
 - **Three Auth Methods** — API Key/Secret (recommended), username/password, or JWT token. All support Docker secrets via `*_FILE` variants.
 - **Runtime Configuration** — Set or change credentials dynamically via `komodo_configure` without restarting the server.
-- **Hardened by Default** — Input validation (Zod), secret scrubbing in logs, rate limiting, DNS rebinding protection, and security headers via Helmet.
+- **Hardened by Default** — Input validation (Zod), best-effort secret scrubbing in operational logs and tool output, rate limiting, DNS rebinding protection, and security headers via Helmet. Retrieved container/build logs and `komodo_exec` output are not scrubbed — see [Secret Redaction](config/README.md#secret-redaction).
 
 ### ⚡ Reliability & Operations
 

--- a/config/README.md
+++ b/config/README.md
@@ -184,6 +184,19 @@ Required when `MCP_TRANSPORT=https`:
 | `MCP_TLS_KEY_PATH` | `transport.tls.key_path` | — | TLS private key file (PEM) |
 | `MCP_TLS_CA_PATH` | `transport.tls.ca_path` | — | CA certificate (optional, for custom CA/mTLS) |
 
+## Secret Redaction
+
+The server scrubs likely secrets out of tool output before it reaches the client transcript. This is a **best-effort, defence-in-depth** measure — key-name and value-shape heuristics, not a guarantee.
+
+| Variable | Config Key | Default | Description |
+|----------|-----------|---------|-------------|
+| `KOMODO_SECRET_SCRUB_ENABLED` | — | `true` | Master switch for secret scrubbing of tool output |
+| `KOMODO_SECRET_SCRUB_KEYS` | — | — | Comma-separated extra key-name fragments to always redact (case-insensitive) |
+
+**Coverage:** structured resource config returned by `*_apply`, `*_delete`, and `*_info` tools — env var blocks, `webhook_secret`, `passkey`, and alerter webhook URLs/emails — via key-name and value-shape heuristics.
+
+**Not covered:** `komodo_exec` output, or logs retrieved via `komodo_container_logs` / `komodo_container_search_logs` / `komodo_build_logs`. Command output and log content are not scanned — don't rely on this feature to keep secrets out of retrieved logs.
+
 ## Security
 
 | Variable | Config Key | Default | Description |

--- a/config/example.config.env
+++ b/config/example.config.env
@@ -178,6 +178,23 @@ MCP_HELMET_CSP=default-src 'self'
 MCP_HELMET_FRAME_OPTIONS=DENY
 
 
+########################
+# SECRET REDACTION     #
+########################
+
+## Master switch for secret scrubbing of tool output.
+## Best-effort, defence-in-depth: key-name + value-shape heuristics over
+## structured resource config (env blocks, webhook_secret, passkey, alerter
+## webhook URLs/emails). Does NOT cover komodo_exec output or retrieved
+## container/build logs.
+## Default: true
+KOMODO_SECRET_SCRUB_ENABLED=true
+
+## Comma-separated extra key-name fragments to always redact (case-insensitive).
+## Optional, no default.
+# KOMODO_SECRET_SCRUB_KEYS=EXTRA_KEY_FRAGMENT,ANOTHER
+
+
 ##############
 # SESSIONS   #
 ##############

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,7 +26,7 @@ export default [
     files: ["**/*.ts"],
     languageOptions: {
       parserOptions: {
-        project: "./tsconfig.json",
+        project: ["./tsconfig.json", "./tsconfig.test.json"],
         tsconfigRootDir: import.meta.dirname,
       },
     },
@@ -102,6 +102,17 @@ export default [
 
       // Not all string comparisons are security-sensitive
       "security/detect-possible-timing-attacks": "warn",
+    },
+  },
+
+  // node:test files — top-level `test(...)` calls are intentionally
+  // fire-and-forget (the test runner awaits them internally), and `as any`
+  // casts on assertion results are acceptable for brevity.
+  {
+    files: ["**/*.test.ts"],
+    rules: {
+      "@typescript-eslint/no-floating-promises": "off",
+      "@typescript-eslint/no-explicit-any": "off",
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:prod": "tsc --project tsconfig.prod.json",
     "start": "node build/index.js",
     "dev": "npm run build && node build/index.js",
+    "test": "tsc -p tsconfig.test.json && node --test \"build-test/**/*.test.js\"",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf build coverage test-results *.tsbuildinfo",
     "clean:all": "rm -rf build node_modules coverage test-results *.tsbuildinfo",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -69,7 +69,12 @@ export const appEnvSchema = z.object({
   /** Comma-separated extra key-name fragments always redacted (case-insensitive). */
   KOMODO_SECRET_SCRUB_KEYS: z
     .string()
-    .transform((s) => s.split(",").map((x) => x.trim()).filter(Boolean))
+    .transform((s) =>
+      s
+        .split(",")
+        .map((x) => x.trim())
+        .filter(Boolean),
+    )
     .optional(),
 });
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -59,6 +59,18 @@ export const appEnvSchema = z.object({
 
   /** Maximum number of dynamic resource entries kept in memory. Default: 1000 */
   KOMODO_RESOURCE_MAX_ENTRIES: z.coerce.number().int().positive().default(1000),
+
+  /** Master switch for secret redaction of tool output. Default: true. */
+  KOMODO_SECRET_SCRUB_ENABLED: z
+    .enum(["true", "false"])
+    .default("true")
+    .transform((v) => v === "true"),
+
+  /** Comma-separated extra key-name fragments always redacted (case-insensitive). */
+  KOMODO_SECRET_SCRUB_KEYS: z
+    .string()
+    .transform((s) => s.split(",").map((x) => x.trim()).filter(Boolean))
+    .optional(),
 });
 
 export type AppEnvConfig = z.infer<typeof appEnvSchema>;

--- a/src/tools/action.ts
+++ b/src/tools/action.ts
@@ -33,9 +33,9 @@ import {
   renderActionList,
   renderActionInfo,
   renderActionResult,
-  tryRegisterResource,
   buildApplyResult,
   buildDeleteResult,
+  buildInfoResult,
 } from "../utils/index.js";
 import {
   actionIdSchema,
@@ -108,24 +108,21 @@ export const getActionInfoTool = defineTool({
       () => komodo.client.read("GetAction", { action: args.action_id }),
       abortSignal,
     );
-    const link = tryRegisterResource({
-      ctx: { sessionId },
-      category: "info",
-      name: `${result.name} (action info)`,
-      mimeType: "application/json",
-      content: JSON.stringify(result, null, 2),
-      ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
-      inlineFull: args.inline_full,
-      description: `Full Action resource for ${result.name}`,
-    });
     const summary = {
       id: result._id?.$oid ?? args.action_id,
       name: result.name,
     };
-    const payload = link ? { summary, resourceLink: link } : { summary, info: result };
-    return structured(payload, {
-      text: renderActionInfo(payload),
-      ...(link ? { links: [link] } : {}),
+    return buildInfoResult({
+      result,
+      summary,
+      register: {
+        ctx: { sessionId },
+        name: `${result.name} (action info)`,
+        ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
+        inlineFull: args.inline_full,
+        description: `Full Action resource for ${result.name}`,
+      },
+      render: (payload) => renderActionInfo(payload),
     });
   },
 });

--- a/src/tools/alerter.ts
+++ b/src/tools/alerter.ts
@@ -25,6 +25,7 @@ import {
   buildApplyResult,
   buildDeleteResult,
   buildInfoResult,
+  redactAlerterEndpoint,
 } from "../utils/index.js";
 import {
   alerterIdSchema,
@@ -100,7 +101,7 @@ export const getAlerterInfoTool = defineTool({
       ...(result.config?.endpoint?.type ? { endpoint_type: result.config.endpoint.type } : {}),
     };
     return buildInfoResult({
-      result,
+      result: redactAlerterEndpoint(result),
       summary,
       register: {
         ctx: { sessionId },
@@ -145,7 +146,7 @@ export const applyAlerterTool = defineTool({
           }),
         abortSignal,
       );
-      const built = buildApplyResult("create", "alerter", name, result);
+      const built = buildApplyResult("create", "alerter", name, redactAlerterEndpoint(result));
       return structured(built.payload, { text: built.text });
     }
     if (!args.alerter) throw AppErrorFactory.validation.fieldRequired("alerter");
@@ -160,7 +161,7 @@ export const applyAlerterTool = defineTool({
         }),
       abortSignal,
     );
-    const built = buildApplyResult("update", "alerter", alerterId, result);
+    const built = buildApplyResult("update", "alerter", alerterId, redactAlerterEndpoint(result));
     return structured(built.payload, { text: built.text });
   },
 });
@@ -182,7 +183,7 @@ export const deleteAlerterTool = defineTool({
       () => komodo.client.write("DeleteAlerter", { id: args.alerter }),
       abortSignal,
     );
-    const built = buildDeleteResult("alerter", args.alerter, result);
+    const built = buildDeleteResult("alerter", args.alerter, redactAlerterEndpoint(result));
     return structured(built.payload, { text: built.text });
   },
 });

--- a/src/tools/alerter.ts
+++ b/src/tools/alerter.ts
@@ -22,9 +22,9 @@ import {
   paginate,
   renderAlerterList,
   renderAlerterInfo,
-  tryRegisterResource,
   buildApplyResult,
   buildDeleteResult,
+  buildInfoResult,
 } from "../utils/index.js";
 import {
   alerterIdSchema,
@@ -93,26 +93,23 @@ export const getAlerterInfoTool = defineTool({
       () => komodo.client.read("GetAlerter", { alerter: args.alerter }),
       abortSignal,
     );
-    const link = tryRegisterResource({
-      ctx: { sessionId },
-      category: "info",
-      name: `${result.name} (alerter info)`,
-      mimeType: "application/json",
-      content: JSON.stringify(result, null, 2),
-      ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
-      inlineFull: args.inline_full,
-      description: `Full alerter resource for ${result.name}`,
-    });
     const summary = {
       id: result._id?.$oid ?? args.alerter,
       name: result.name,
       ...(result.config?.enabled !== undefined ? { enabled: result.config.enabled } : {}),
       ...(result.config?.endpoint?.type ? { endpoint_type: result.config.endpoint.type } : {}),
     };
-    const payload = link ? { summary, resourceLink: link } : { summary, info: result };
-    return structured(payload, {
-      text: renderAlerterInfo(payload),
-      ...(link ? { links: [link] } : {}),
+    return buildInfoResult({
+      result,
+      summary,
+      register: {
+        ctx: { sessionId },
+        name: `${result.name} (alerter info)`,
+        ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
+        inlineFull: args.inline_full,
+        description: `Full alerter resource for ${result.name}`,
+      },
+      render: (payload) => renderAlerterInfo(payload),
     });
   },
 });

--- a/src/tools/build.ts
+++ b/src/tools/build.ts
@@ -32,6 +32,7 @@ import {
   tryRegisterResource,
   buildApplyResult,
   buildDeleteResult,
+  buildInfoResult,
 } from "../utils/index.js";
 import {
   buildIdSchema,
@@ -117,16 +118,6 @@ export const getBuildInfoTool = defineTool({
       () => komodo.client.read("GetBuild", { build: args.build }),
       abortSignal,
     );
-    const link = tryRegisterResource({
-      ctx: { sessionId },
-      category: "info",
-      name: `${result.name} (build info)`,
-      mimeType: "application/json",
-      content: JSON.stringify(result, null, 2),
-      ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
-      inlineFull: args.inline_full,
-      description: `Full build resource for ${result.name}`,
-    });
     const summary = {
       id: result._id?.$oid ?? args.build,
       name: result.name,
@@ -136,10 +127,17 @@ export const getBuildInfoTool = defineTool({
       ...(result.config?.branch ? { branch: result.config.branch } : {}),
       ...(result.info?.last_built_at ? { last_built_at: result.info.last_built_at } : {}),
     };
-    const payload = link ? { summary, resourceLink: link } : { summary, info: result };
-    return structured(payload, {
-      text: renderBuildInfo(payload),
-      ...(link ? { links: [link] } : {}),
+    return buildInfoResult({
+      result,
+      summary,
+      register: {
+        ctx: { sessionId },
+        name: `${result.name} (build info)`,
+        ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
+        inlineFull: args.inline_full,
+        description: `Full build resource for ${result.name}`,
+      },
+      render: (payload) => renderBuildInfo(payload),
     });
   },
 });

--- a/src/tools/container.ts
+++ b/src/tools/container.ts
@@ -38,6 +38,7 @@ import {
   renderContainerSearchLogs,
   renderActionResult,
   tryRegisterResource,
+  scrubResource,
 } from "../utils/index.js";
 import {
   containerActionInputSchema,
@@ -112,11 +113,15 @@ export const inspectContainerTool = defineTool({
   requiredScopes: [ToolScopes.READ],
   handler: async (args, { abortSignal, sessionId }) => {
     const komodo = requireClient();
-    const result = await wrapApiCall(
+    const raw = await wrapApiCall(
       "inspectContainer",
       () => komodo.client.read("InspectDockerContainer", { server: args.server, container: args.container }),
       abortSignal,
     );
+    // Config.Env is the resolved runtime environment, so a secret stored as a
+    // Komodo Variable surfaces here as plaintext — scrub before it reaches the
+    // transcript. scrubResource redacts secret KEY=value entries in the Env array.
+    const result = scrubResource(raw) as typeof raw;
     const link = tryRegisterResource({
       ctx: { sessionId },
       category: "inspect",

--- a/src/tools/deployment.ts
+++ b/src/tools/deployment.ts
@@ -27,9 +27,9 @@ import {
   renderDeploymentList,
   renderDeploymentInfo,
   renderActionResult,
-  tryRegisterResource,
   buildApplyResult,
   buildDeleteResult,
+  buildInfoResult,
 } from "../utils/index.js";
 import {
   deploymentApplyInputSchema,
@@ -103,21 +103,18 @@ export const getDeploymentInfoTool = defineTool({
       () => komodo.client.read("GetDeployment", { deployment: args.deployment }),
       abortSignal,
     );
-    const link = tryRegisterResource({
-      ctx: { sessionId },
-      category: "info",
-      name: `${args.deployment} (deployment info)`,
-      mimeType: "application/json",
-      content: JSON.stringify(result, null, 2),
-      ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
-      inlineFull: args.inline_full,
-      description: `Full deployment resource for ${args.deployment}`,
-    });
     const summary = { id: args.deployment, name: args.deployment };
-    const payload = link ? { summary, resourceLink: link } : { summary, info: result };
-    return structured(payload, {
-      text: renderDeploymentInfo(payload),
-      ...(link ? { links: [link] } : {}),
+    return buildInfoResult({
+      result,
+      summary,
+      register: {
+        ctx: { sessionId },
+        name: `${args.deployment} (deployment info)`,
+        ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
+        inlineFull: args.inline_full,
+        description: `Full deployment resource for ${args.deployment}`,
+      },
+      render: (payload) => renderDeploymentInfo(payload),
     });
   },
 });

--- a/src/tools/procedure.ts
+++ b/src/tools/procedure.ts
@@ -27,9 +27,9 @@ import {
   renderProcedureList,
   renderProcedureInfo,
   renderActionResult,
-  tryRegisterResource,
   buildApplyResult,
   buildDeleteResult,
+  buildInfoResult,
 } from "../utils/index.js";
 import {
   procedureIdSchema,
@@ -102,24 +102,21 @@ export const getProcedureInfoTool = defineTool({
       () => komodo.client.read("GetProcedure", { procedure: args.procedure }),
       abortSignal,
     );
-    const link = tryRegisterResource({
-      ctx: { sessionId },
-      category: "info",
-      name: `${result.name} (procedure info)`,
-      mimeType: "application/json",
-      content: JSON.stringify(result, null, 2),
-      ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
-      inlineFull: args.inline_full,
-      description: `Full procedure resource for ${result.name}`,
-    });
     const summary = {
       id: result._id?.$oid ?? args.procedure,
       name: result.name,
     };
-    const payload = link ? { summary, resourceLink: link } : { summary, info: result };
-    return structured(payload, {
-      text: renderProcedureInfo(payload),
-      ...(link ? { links: [link] } : {}),
+    return buildInfoResult({
+      result,
+      summary,
+      register: {
+        ctx: { sessionId },
+        name: `${result.name} (procedure info)`,
+        ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
+        inlineFull: args.inline_full,
+        description: `Full procedure resource for ${result.name}`,
+      },
+      render: (payload) => renderProcedureInfo(payload),
     });
   },
 });

--- a/src/tools/repo.ts
+++ b/src/tools/repo.ts
@@ -27,9 +27,9 @@ import {
   renderRepoList,
   renderRepoInfo,
   renderActionResult,
-  tryRegisterResource,
   buildApplyResult,
   buildDeleteResult,
+  buildInfoResult,
 } from "../utils/index.js";
 import {
   repoIdSchema,
@@ -103,16 +103,6 @@ export const getRepoInfoTool = defineTool({
   handler: async (args, { abortSignal, sessionId }) => {
     const komodo = requireClient();
     const result = await wrapApiCall("getRepo", () => komodo.client.read("GetRepo", { repo: args.repo }), abortSignal);
-    const link = tryRegisterResource({
-      ctx: { sessionId },
-      category: "info",
-      name: `${result.name} (repo info)`,
-      mimeType: "application/json",
-      content: JSON.stringify(result, null, 2),
-      ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
-      inlineFull: args.inline_full,
-      description: `Full repo resource for ${result.name}`,
-    });
     const summary = {
       id: result._id?.$oid ?? args.repo,
       name: result.name,
@@ -121,10 +111,17 @@ export const getRepoInfoTool = defineTool({
       ...(result.config?.repo ? { repo: result.config.repo } : {}),
       ...(result.config?.branch ? { branch: result.config.branch } : {}),
     };
-    const payload = link ? { summary, resourceLink: link } : { summary, info: result };
-    return structured(payload, {
-      text: renderRepoInfo(payload),
-      ...(link ? { links: [link] } : {}),
+    return buildInfoResult({
+      result,
+      summary,
+      register: {
+        ctx: { sessionId },
+        name: `${result.name} (repo info)`,
+        ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
+        inlineFull: args.inline_full,
+        description: `Full repo resource for ${result.name}`,
+      },
+      render: (payload) => renderRepoInfo(payload),
     });
   },
 });

--- a/src/tools/resource-sync.ts
+++ b/src/tools/resource-sync.ts
@@ -27,10 +27,10 @@ import {
   renderResourceSyncList,
   renderResourceSyncInfo,
   renderActionResult,
-  tryRegisterResource,
   formatActionResponse,
   buildApplyResult,
   buildDeleteResult,
+  buildInfoResult,
 } from "../utils/index.js";
 import {
   resourceSyncIdSchema,
@@ -111,24 +111,21 @@ export const getResourceSyncInfoTool = defineTool({
       () => komodo.client.read("GetResourceSync", { sync: args.resource_sync }),
       abortSignal,
     );
-    const link = tryRegisterResource({
-      ctx: { sessionId },
-      category: "info",
-      name: `${result.name} (resource sync info)`,
-      mimeType: "application/json",
-      content: JSON.stringify(result, null, 2),
-      ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
-      inlineFull: args.inline_full,
-      description: `Full resource sync payload for ${result.name}`,
-    });
     const summary = {
       id: result._id?.$oid ?? args.resource_sync,
       name: result.name,
     };
-    const payload = link ? { summary, resourceLink: link } : { summary, info: result };
-    return structured(payload, {
-      text: renderResourceSyncInfo(payload),
-      ...(link ? { links: [link] } : {}),
+    return buildInfoResult({
+      result,
+      summary,
+      register: {
+        ctx: { sessionId },
+        name: `${result.name} (resource sync info)`,
+        ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
+        inlineFull: args.inline_full,
+        description: `Full resource sync payload for ${result.name}`,
+      },
+      render: (payload) => renderResourceSyncInfo(payload),
     });
   },
 });

--- a/src/tools/server.ts
+++ b/src/tools/server.ts
@@ -36,9 +36,9 @@ import {
   renderServerInfo,
   renderServerStats,
   renderActionResult,
-  tryRegisterResource,
   buildApplyResult,
   buildDeleteResult,
+  buildInfoResult,
 } from "../utils/index.js";
 
 type ServerListItem = Types.ServerListItem;
@@ -127,21 +127,18 @@ export const getServerInfoTool = defineTool({
       () => komodo.client.read("GetServer", { server: args.server }),
       abortSignal,
     );
-    const link = tryRegisterResource({
-      ctx: { sessionId },
-      category: "info",
-      name: `${args.server} (server info)`,
-      mimeType: "application/json",
-      content: JSON.stringify(result, null, 2),
-      ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
-      inlineFull: args.inline_full,
-      description: `Full server resource for ${args.server}`,
-    });
     const summary = { id: args.server, name: args.server };
-    const payload = link ? { summary, resourceLink: link } : { summary, info: result };
-    return structured(payload, {
-      text: renderServerInfo(payload),
-      ...(link ? { links: [link] } : {}),
+    return buildInfoResult({
+      result,
+      summary,
+      register: {
+        ctx: { sessionId },
+        name: `${args.server} (server info)`,
+        ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
+        inlineFull: args.inline_full,
+        description: `Full server resource for ${args.server}`,
+      },
+      render: (payload) => renderServerInfo(payload),
     });
   },
 });

--- a/src/tools/stack.ts
+++ b/src/tools/stack.ts
@@ -198,7 +198,9 @@ export const deleteStackTool = defineTool({
       () => komodo.client.write("DeleteStack", { id: args.stack }),
       abortSignal,
     );
-    const built = buildDeleteResult("stack", args.stack, result);
+    // The deleted-resource snapshot carries the post-interpolation
+    // deployed_config/deployed_contents — strip them before the transcript.
+    const built = buildDeleteResult("stack", args.stack, redactDeployedSecrets(result));
     return structured(built.payload, { text: built.text });
   },
 });

--- a/src/tools/stack.ts
+++ b/src/tools/stack.ts
@@ -47,6 +47,27 @@ import {
 type StackListItem = Types.StackListItem;
 
 // ============================================================================
+// Secret Redaction
+// ============================================================================
+
+/**
+ * Strip the post-interpolation deploy artifacts from a stack before returning it.
+ *
+ * `deployed_config` (the `docker compose config` output) and `deployed_contents`
+ * carry `[[variable.x]]` references already expanded to their real values, so a
+ * secret interpolated into a compose file or clone URL would otherwise surface
+ * in the tool result — and from there into the client transcript and model
+ * provider. The source config (`file_contents`, `environment`) is retained.
+ */
+function redactDeployedSecrets(stack: Types.Stack): Types.Stack {
+  if (!stack.info) return stack;
+  const info = { ...stack.info };
+  delete info.deployed_config;
+  delete info.deployed_contents;
+  return { ...stack, info };
+}
+
+// ============================================================================
 // List
 // ============================================================================
 
@@ -92,10 +113,8 @@ export const getStackInfoTool = defineTool({
   requiredScopes: [ToolScopes.READ],
   handler: async (args, { abortSignal, sessionId }) => {
     const komodo = requireClient();
-    const result = await wrapApiCall(
-      "getStackInfo",
-      () => komodo.client.read("GetStack", { stack: args.stack }),
-      abortSignal,
+    const result = redactDeployedSecrets(
+      await wrapApiCall("getStackInfo", () => komodo.client.read("GetStack", { stack: args.stack }), abortSignal),
     );
     const link = tryRegisterResource({
       ctx: { sessionId },
@@ -141,7 +160,7 @@ export const applyStackTool = defineTool({
         () => komodo.client.write("CreateStack", { name, config: stackConfig }),
         abortSignal,
       );
-      const built = buildApplyResult("create", "stack", name, result);
+      const built = buildApplyResult("create", "stack", name, redactDeployedSecrets(result));
       return structured(built.payload, { text: built.text });
     }
     if (!args.stack) throw AppErrorFactory.validation.fieldRequired("stack");
@@ -156,7 +175,7 @@ export const applyStackTool = defineTool({
         }),
       abortSignal,
     );
-    const built = buildApplyResult("update", "stack", stackId, result);
+    const built = buildApplyResult("update", "stack", stackId, redactDeployedSecrets(result));
     return structured(built.payload, { text: built.text });
   },
 });

--- a/src/tools/stack.ts
+++ b/src/tools/stack.ts
@@ -27,9 +27,9 @@ import {
   renderStackList,
   renderStackInfo,
   renderActionResult,
-  tryRegisterResource,
   buildApplyResult,
   buildDeleteResult,
+  buildInfoResult,
 } from "../utils/index.js";
 import {
   stackApplyInputSchema,
@@ -116,21 +116,18 @@ export const getStackInfoTool = defineTool({
     const result = redactDeployedSecrets(
       await wrapApiCall("getStackInfo", () => komodo.client.read("GetStack", { stack: args.stack }), abortSignal),
     );
-    const link = tryRegisterResource({
-      ctx: { sessionId },
-      category: "info",
-      name: `${args.stack} (stack info)`,
-      mimeType: "application/json",
-      content: JSON.stringify(result, null, 2),
-      ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
-      inlineFull: args.inline_full,
-      description: `Full stack resource for ${args.stack}`,
-    });
     const summary = { id: args.stack, name: args.stack };
-    const payload = link ? { summary, resourceLink: link } : { summary, info: result };
-    return structured(payload, {
-      text: renderStackInfo(payload),
-      ...(link ? { links: [link] } : {}),
+    return buildInfoResult({
+      result,
+      summary,
+      register: {
+        ctx: { sessionId },
+        name: `${args.stack} (stack info)`,
+        ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
+        inlineFull: args.inline_full,
+        description: `Full stack resource for ${args.stack}`,
+      },
+      render: (payload) => renderStackInfo(payload),
     });
   },
 });

--- a/src/tools/swarm.ts
+++ b/src/tools/swarm.ts
@@ -34,9 +34,9 @@ import {
   renderSwarmNodesList,
   renderSwarmServicesList,
   renderActionResult,
-  tryRegisterResource,
   buildApplyResult,
   buildDeleteResult,
+  buildInfoResult,
 } from "../utils/index.js";
 import {
   swarmIdSchema,
@@ -112,25 +112,22 @@ export const getSwarmInfoTool = defineTool({
       () => komodo.client.read("GetSwarm", { swarm: args.swarm }),
       abortSignal,
     );
-    const link = tryRegisterResource({
-      ctx: { sessionId },
-      category: "info",
-      name: `${result.name} (swarm info)`,
-      mimeType: "application/json",
-      content: JSON.stringify(result, null, 2),
-      ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
-      inlineFull: args.inline_full,
-      description: `Full swarm resource for ${result.name}`,
-    });
     const summary = {
       id: result._id?.$oid ?? args.swarm,
       name: result.name,
       ...(result.config?.server_ids ? { server_ids: result.config.server_ids } : {}),
     };
-    const payload = link ? { summary, resourceLink: link } : { summary, info: result };
-    return structured(payload, {
-      text: renderSwarmInfo(payload),
-      ...(link ? { links: [link] } : {}),
+    return buildInfoResult({
+      result,
+      summary,
+      register: {
+        ctx: { sessionId },
+        name: `${result.name} (swarm info)`,
+        ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
+        inlineFull: args.inline_full,
+        description: `Full swarm resource for ${result.name}`,
+      },
+      render: (payload) => renderSwarmInfo(payload),
     });
   },
 });

--- a/src/tools/variable.ts
+++ b/src/tools/variable.ts
@@ -59,6 +59,15 @@ function projectVariable(v: Variable): {
   };
 }
 
+/**
+ * Mask a secret variable's value in the full resource returned by the write and
+ * delete tools — unlike reads, write responses echo the plaintext value even for
+ * `is_secret` variables. Passes non-secrets (and `undefined`) through.
+ */
+function maskSecretValue(v: Variable | undefined): Variable | undefined {
+  return v?.is_secret ? { ...v, value: SECRET_PLACEHOLDER } : v;
+}
+
 // ============================================================================
 // List
 // ============================================================================
@@ -138,7 +147,7 @@ export const applyVariableTool = defineTool({
         () => komodo.client.write("CreateVariable", params),
         abortSignal,
       );
-      const built = buildApplyResult("create", "variable", args.name, result);
+      const built = buildApplyResult("create", "variable", args.name, maskSecretValue(result));
       return structured(built.payload, { text: built.text });
     }
     // update — dispatch to one or more endpoints based on which fields are set
@@ -170,7 +179,7 @@ export const applyVariableTool = defineTool({
         abortSignal,
       );
     }
-    const built = buildApplyResult("update", "variable", args.name, updated);
+    const built = buildApplyResult("update", "variable", args.name, maskSecretValue(updated));
     return structured(built.payload, { text: built.text });
   },
 });
@@ -195,8 +204,7 @@ export const deleteVariableTool = defineTool({
     );
     // The deleted-resource snapshot echoes the variable verbatim — redact a
     // secret value before it reaches the client transcript.
-    const safe = result.is_secret ? { ...result, value: SECRET_PLACEHOLDER } : result;
-    const built = buildDeleteResult("variable", args.name, safe);
+    const built = buildDeleteResult("variable", args.name, maskSecretValue(result));
     return structured(built.payload, { text: built.text });
   },
 });

--- a/src/tools/variable.ts
+++ b/src/tools/variable.ts
@@ -26,6 +26,7 @@ import {
   renderVariableInfo,
   buildApplyResult,
   buildDeleteResult,
+  REDACTED,
 } from "../utils/index.js";
 import {
   variableNameSchema,
@@ -39,9 +40,6 @@ import {
 
 type Variable = Types.Variable;
 
-/** Placeholder substituted for secret variable values in tool output. */
-const SECRET_PLACEHOLDER = "[redacted]";
-
 function projectVariable(v: Variable): {
   name: string;
   value: string;
@@ -53,7 +51,7 @@ function projectVariable(v: Variable): {
     // Never surface a secret's value: MCP results are persisted to the client
     // transcript (and sent to the model provider), so redact regardless of the
     // caller's Komodo scope — core only redacts for non-admin keys.
-    value: v.is_secret ? SECRET_PLACEHOLDER : (v.value ?? ""),
+    value: v.is_secret ? REDACTED : (v.value ?? ""),
     ...(v.description !== undefined && v.description !== "" ? { description: v.description } : {}),
     ...(v.is_secret ? { is_secret: true } : {}),
   };
@@ -65,7 +63,7 @@ function projectVariable(v: Variable): {
  * `is_secret` variables. Passes non-secrets (and `undefined`) through.
  */
 function maskSecretValue(v: Variable | undefined): Variable | undefined {
-  return v?.is_secret ? { ...v, value: SECRET_PLACEHOLDER } : v;
+  return v?.is_secret ? { ...v, value: REDACTED } : v;
 }
 
 // ============================================================================

--- a/src/tools/variable.ts
+++ b/src/tools/variable.ts
@@ -39,6 +39,9 @@ import {
 
 type Variable = Types.Variable;
 
+/** Placeholder substituted for secret variable values in tool output. */
+const SECRET_PLACEHOLDER = "[redacted]";
+
 function projectVariable(v: Variable): {
   name: string;
   value: string;
@@ -47,7 +50,10 @@ function projectVariable(v: Variable): {
 } {
   return {
     name: v.name,
-    value: v.value ?? "",
+    // Never surface a secret's value: MCP results are persisted to the client
+    // transcript (and sent to the model provider), so redact regardless of the
+    // caller's Komodo scope — core only redacts for non-admin keys.
+    value: v.is_secret ? SECRET_PLACEHOLDER : (v.value ?? ""),
     ...(v.description !== undefined && v.description !== "" ? { description: v.description } : {}),
     ...(v.is_secret ? { is_secret: true } : {}),
   };
@@ -187,7 +193,10 @@ export const deleteVariableTool = defineTool({
       () => komodo.client.write("DeleteVariable", { name: args.name }),
       abortSignal,
     );
-    const built = buildDeleteResult("variable", args.name, result);
+    // The deleted-resource snapshot echoes the variable verbatim — redact a
+    // secret value before it reaches the client transcript.
+    const safe = result.is_secret ? { ...result, value: SECRET_PLACEHOLDER } : result;
+    const built = buildDeleteResult("variable", args.name, safe);
     return structured(built.payload, { text: built.text });
   },
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,7 +16,7 @@
 export { requireClient, checkCancelled, wrapApiCall } from "./api-helpers.js";
 
 // --- Secret Redaction ---
-export { scrubResource } from "./redact.js";
+export { scrubResource, redactAlerterEndpoint, REDACTED } from "./redact.js";
 
 // --- Resource Links (ephemeral session-bound payloads) ---
 export { tryRegisterResource } from "./resource-link.js";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,6 +15,9 @@
 // --- API Helpers ---
 export { requireClient, checkCancelled, wrapApiCall } from "./api-helpers.js";
 
+// --- Secret Redaction ---
+export { scrubResource } from "./redact.js";
+
 // --- Resource Links (ephemeral session-bound payloads) ---
 export { tryRegisterResource } from "./resource-link.js";
 export type { ResourceCategory, ResourceLinkContext, RegisterResourceOptions } from "./resource-link.js";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -35,6 +35,7 @@ export {
   formatActionResponse,
   buildApplyResult,
   buildDeleteResult,
+  buildInfoResult,
   type ActionType,
   type ResourceType,
   type ActionResponseOptions,

--- a/src/utils/redact.test.ts
+++ b/src/utils/redact.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { scrubResource } from "./redact.js";
+import { scrubResource, redactAlerterEndpoint } from "./redact.js";
 
 test("scrubs a sensitively-named field (webhook_secret)", () => {
   const out = scrubResource({ config: { webhook_secret: "shhh-123" } }) as any;
@@ -39,4 +39,16 @@ test("disabled switch passes input through unchanged", () => {
   // (Env is default-on in the rig; this asserts identity when a plain object has no secrets.)
   const input = { a: 1, b: "hello" };
   assert.deepEqual(scrubResource(input), input);
+});
+
+test("redactAlerterEndpoint masks endpoint url and email", () => {
+  const out: any = redactAlerterEndpoint({
+    config: { endpoint: { type: "Slack", params: { url: "https://hooks.slack.com/services/T/B/xyz" } } },
+  } as any);
+  assert.notEqual(out.config.endpoint.params.url, "https://hooks.slack.com/services/T/B/xyz");
+});
+
+test("redactAlerterEndpoint passes an alerter with no endpoint through", () => {
+  const a: any = { config: {} };
+  assert.deepEqual(redactAlerterEndpoint(a), a);
 });

--- a/src/utils/redact.test.ts
+++ b/src/utils/redact.test.ts
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { scrubResource } from "./redact.js";
+
+test("scrubs a sensitively-named field (webhook_secret)", () => {
+  const out = scrubResource({ config: { webhook_secret: "shhh-123" } }) as any;
+  assert.notEqual(out.config.webhook_secret, "shhh-123");
+});
+
+test("scrubs secret lines inside an env block string", () => {
+  const out = scrubResource({ config: { environment: "HOST=h\nAPI_KEY=abc123\nDB_PASSWORD=hunter2" } }) as any;
+  assert.doesNotMatch(out.config.environment, /abc123|hunter2/);
+  assert.match(out.config.environment, /HOST=h/);
+});
+
+test("scrubs a connection-string value (git clone token)", () => {
+  const out = scrubResource({ config: { command: "git clone https://x:ghp_TOKEN@github.com/o/r.git" } }) as any;
+  assert.doesNotMatch(out.config.command, /ghp_TOKEN/);
+});
+
+test("false-positive gate: benign resource-config fields survive", () => {
+  const input = {
+    name: "my-stack",
+    config: { server_id: "srv-1", builder_id: "b-2", branch: "main", git_account: "octocat", repo: "o/r" },
+    info: { state: "running" },
+  };
+  const out = scrubResource(input) as any;
+  assert.equal(out.name, "my-stack");
+  assert.equal(out.config.server_id, "srv-1");
+  assert.equal(out.config.builder_id, "b-2");
+  assert.equal(out.config.branch, "main");
+  assert.equal(out.config.git_account, "octocat");
+  assert.equal(out.config.repo, "o/r");
+  assert.equal(out.info.state, "running");
+});
+
+test("disabled switch passes input through unchanged", () => {
+  // Verified separately; scrubResource honours KOMODO_SECRET_SCRUB_ENABLED=false.
+  // (Env is default-on in the rig; this asserts identity when a plain object has no secrets.)
+  const input = { a: 1, b: "hello" };
+  assert.deepEqual(scrubResource(input), input);
+});

--- a/src/utils/redact.test.ts
+++ b/src/utils/redact.test.ts
@@ -34,9 +34,36 @@ test("false-positive gate: benign resource-config fields survive", () => {
   assert.equal(out.info.state, "running");
 });
 
-test("disabled switch passes input through unchanged", () => {
-  // Verified separately; scrubResource honours KOMODO_SECRET_SCRUB_ENABLED=false.
-  // (Env is default-on in the rig; this asserts identity when a plain object has no secrets.)
+test("false-positive gate: allowlisted public-key/flag fields survive, control field stays redacted", () => {
+  const input = {
+    config: {
+      webhook_secret: "shh",
+      secret_args: true,
+      skip_secret_interp: true,
+      auto_rotate_keys: false,
+    },
+    info: {
+      public_key: "ssh-ed25519 AAAA...",
+      attempted_public_key: "ssh-ed25519 BBBB...",
+    },
+  };
+  const out = scrubResource(input) as any;
+  // Allowlisted benign fields survive unredacted.
+  assert.equal(out.info.public_key, "ssh-ed25519 AAAA...");
+  assert.equal(out.info.attempted_public_key, "ssh-ed25519 BBBB...");
+  assert.equal(out.config.skip_secret_interp, true);
+  assert.equal(out.config.auto_rotate_keys, false);
+  // Control: fields NOT on the allowlist stay redacted.
+  assert.notEqual(out.config.webhook_secret, "shh");
+  assert.notEqual(out.config.secret_args, true);
+});
+
+test("passes input through unchanged when a plain object has no secrets (enable-gate itself verified by inspection)", () => {
+  // This does NOT exercise KOMODO_SECRET_SCRUB_ENABLED=false — `config` is a frozen
+  // singleton parsed at module load, so toggling it here would need a brittle
+  // env-reload harness. The gate at scrubResource's `if (!config.KOMODO_SECRET_SCRUB_ENABLED)
+  // return result;` is verified by inspection instead. This test only asserts that
+  // scrubbing a secret-free object is a no-op.
   const input = { a: 1, b: "hello" };
   assert.deepEqual(scrubResource(input), input);
 });
@@ -46,6 +73,13 @@ test("redactAlerterEndpoint masks endpoint url and email", () => {
     config: { endpoint: { type: "Slack", params: { url: "https://hooks.slack.com/services/T/B/xyz" } } },
   } as any);
   assert.notEqual(out.config.endpoint.params.url, "https://hooks.slack.com/services/T/B/xyz");
+});
+
+test("redactAlerterEndpoint masks email on an Ntfy endpoint", () => {
+  const out: any = redactAlerterEndpoint({
+    config: { endpoint: { type: "Ntfy", params: { url: "https://ntfy.sh/x", email: "a@b.com" } } },
+  } as any);
+  assert.notEqual(out.config.endpoint.params.email, "a@b.com");
 });
 
 test("redactAlerterEndpoint passes an alerter with no endpoint through", () => {

--- a/src/utils/redact.test.ts
+++ b/src/utils/redact.test.ts
@@ -36,6 +36,7 @@ test("false-positive gate: benign resource-config fields survive", () => {
 
 test("false-positive gate: allowlisted public-key/flag fields survive, control field stays redacted", () => {
   const input = {
+    is_secret: true,
     config: {
       webhook_secret: "shh",
       secret_args: true,
@@ -49,6 +50,7 @@ test("false-positive gate: allowlisted public-key/flag fields survive, control f
   };
   const out = scrubResource(input) as any;
   // Allowlisted benign fields survive unredacted.
+  assert.equal(out.is_secret, true);
   assert.equal(out.info.public_key, "ssh-ed25519 AAAA...");
   assert.equal(out.info.attempted_public_key, "ssh-ed25519 BBBB...");
   assert.equal(out.config.skip_secret_interp, true);

--- a/src/utils/redact.test.ts
+++ b/src/utils/redact.test.ts
@@ -88,3 +88,12 @@ test("redactAlerterEndpoint passes an alerter with no endpoint through", () => {
   const a: any = { config: {} };
   assert.deepEqual(redactAlerterEndpoint(a), a);
 });
+
+test("scrubs secret KEY=value entries in a Config.Env-style array (container inspect)", () => {
+  const out: any = scrubResource({
+    Config: { Env: ["HOST=localhost", "API_KEY=abc123", "DB_PASSWORD=hunter2"] },
+  });
+  const env = out.Config.Env.join("\n");
+  assert.doesNotMatch(env, /abc123|hunter2/);
+  assert.match(env, /HOST=localhost/);
+});

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -11,7 +11,12 @@ import { SecretScrubber } from "mcp-server-framework/logger";
 import type { Types } from "komodo_client";
 import { config } from "../config/index.js";
 
-export const REDACTED = "[redacted]";
+/**
+ * Redaction marker. Matches the framework `SecretScrubber`'s internal
+ * `REDACTED_VALUE` (not exported) so our own masking (variable value, alerter
+ * URL) and the scrubber's output present one consistent marker in tool results.
+ */
+export const REDACTED = "**********";
 
 let scrubber: SecretScrubber | undefined;
 function getScrubber(): SecretScrubber {
@@ -33,6 +38,7 @@ const REDACT_ALLOWLIST = new Set([
   "periphery_public_key",
   "skip_secret_interp",
   "auto_rotate_keys",
+  "is_secret",
 ]);
 
 /** Walk `scrubbed` and `original` in parallel, restoring allowlisted keys' original values. */

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -8,7 +8,10 @@
  * @module utils/redact
  */
 import { SecretScrubber } from "mcp-server-framework/logger";
+import type { Types } from "komodo_client";
 import { config } from "../config/index.js";
+
+export const REDACTED = "[redacted]";
 
 let scrubber: SecretScrubber | undefined;
 function getScrubber(): SecretScrubber {
@@ -22,4 +25,27 @@ function getScrubber(): SecretScrubber {
 export function scrubResource(result: unknown): unknown {
   if (!config.KOMODO_SECRET_SCRUB_ENABLED) return result;
   return getScrubber().scrubObject(result);
+}
+
+/**
+ * Mask the alerter webhook URL/email.
+ *
+ * The generic `scrubResource` heuristics miss this: the key name (`params.url`)
+ * is innocuous and the value (a webhook URL) has no detectable secret shape.
+ */
+export function redactAlerterEndpoint(alerter: Types.Alerter): Types.Alerter {
+  const endpoint = alerter.config?.endpoint;
+  const params = endpoint?.params as { url?: string; email?: string } | undefined;
+  if (!endpoint || !params) return alerter;
+  const masked = {
+    ...params,
+    ...(params.url ? { url: REDACTED } : {}),
+    ...(params.email ? { email: REDACTED } : {}),
+    // @type-variance — masked values re-widen the discriminated `AlerterEndpoint.params`
+    // union (e.g. Pushover requires `url`); the `type` tag is preserved unchanged above.
+  } as typeof endpoint.params;
+  return {
+    ...alerter,
+    config: { ...alerter.config, endpoint: { ...endpoint, params: masked } },
+  };
 }

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -21,10 +21,40 @@ function getScrubber(): SecretScrubber {
   return scrubber;
 }
 
+/**
+ * Key names that `SecretScrubber` over-redacts via bare-substring matching
+ * (`isSensitiveKey`) but which are never actually secret. Restored to their
+ * original value after scrubbing. `SecretScrubber` has no blocklist hook, so
+ * this is a post-pass rather than an input to the scrubber itself.
+ */
+const REDACT_ALLOWLIST = new Set([
+  "public_key",
+  "attempted_public_key",
+  "periphery_public_key",
+  "skip_secret_interp",
+  "auto_rotate_keys",
+]);
+
+/** Walk `scrubbed` and `original` in parallel, restoring allowlisted keys' original values. */
+function restoreAllowlisted(scrubbed: unknown, original: unknown): unknown {
+  if (Array.isArray(scrubbed) && Array.isArray(original)) {
+    return scrubbed.map((v, i) => restoreAllowlisted(v, original[i]));
+  }
+  if (scrubbed && typeof scrubbed === "object" && original && typeof original === "object") {
+    const out: Record<string, unknown> = { ...(scrubbed as Record<string, unknown>) };
+    const orig = original as Record<string, unknown>;
+    for (const k of Object.keys(out)) {
+      out[k] = REDACT_ALLOWLIST.has(k) ? orig[k] : restoreAllowlisted(out[k], orig[k]);
+    }
+    return out;
+  }
+  return scrubbed;
+}
+
 /** Scrub secrets from a tool result before it reaches the client transcript. */
 export function scrubResource(result: unknown): unknown {
   if (!config.KOMODO_SECRET_SCRUB_ENABLED) return result;
-  return getScrubber().scrubObject(result);
+  return restoreAllowlisted(getScrubber().scrubObject(result), result);
 }
 
 /**

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,0 +1,25 @@
+/**
+ * Secret redaction for tool output.
+ *
+ * A single choke-point scrub applied inside the shared result builders. Delegates
+ * to the framework SecretScrubber (key-name + value-shape heuristics); best-effort,
+ * not a guarantee. Gated by KOMODO_SECRET_SCRUB_ENABLED.
+ *
+ * @module utils/redact
+ */
+import { SecretScrubber } from "mcp-server-framework/logger";
+import { config } from "../config/index.js";
+
+let scrubber: SecretScrubber | undefined;
+function getScrubber(): SecretScrubber {
+  if (!scrubber) {
+    scrubber = new SecretScrubber(config.KOMODO_SECRET_SCRUB_KEYS ?? []);
+  }
+  return scrubber;
+}
+
+/** Scrub secrets from a tool result before it reaches the client transcript. */
+export function scrubResource(result: unknown): unknown {
+  if (!config.KOMODO_SECRET_SCRUB_ENABLED) return result;
+  return getScrubber().scrubObject(result);
+}

--- a/src/utils/response-formatter.test.ts
+++ b/src/utils/response-formatter.test.ts
@@ -1,0 +1,16 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildApplyResult, buildDeleteResult } from "./response-formatter.js";
+
+test("buildApplyResult scrubs secret env in the returned resource", () => {
+  const built = buildApplyResult("update", "stack", "s", { config: { environment: "API_KEY=abc123" } });
+  const env = (built.payload.resource as any).config.environment;
+  assert.doesNotMatch(env, /abc123/);
+  assert.doesNotMatch(built.text, /abc123/);
+});
+
+test("buildDeleteResult scrubs webhook_secret in the returned resource", () => {
+  const built = buildDeleteResult("build", "b", { config: { webhook_secret: "shh-987" } });
+  assert.notEqual((built.payload.resource as any).config.webhook_secret, "shh-987");
+  assert.doesNotMatch(built.text, /shh-987/);
+});

--- a/src/utils/response-formatter.test.ts
+++ b/src/utils/response-formatter.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildApplyResult, buildDeleteResult } from "./response-formatter.js";
+import { buildApplyResult, buildDeleteResult, buildInfoResult } from "./response-formatter.js";
 
 test("buildApplyResult scrubs secret env in the returned resource", () => {
   const built = buildApplyResult("update", "stack", "s", { config: { environment: "API_KEY=abc123" } });
@@ -13,4 +13,15 @@ test("buildDeleteResult scrubs webhook_secret in the returned resource", () => {
   const built = buildDeleteResult("build", "b", { config: { webhook_secret: "shh-987" } });
   assert.notEqual((built.payload.resource as any).config.webhook_secret, "shh-987");
   assert.doesNotMatch(built.text, /shh-987/);
+});
+
+test("buildInfoResult scrubs secret env in the inline info payload", () => {
+  const res = buildInfoResult({
+    result: { config: { environment: "TOKEN=leakme" } },
+    summary: { id: "d", name: "d" },
+    register: { ctx: {}, name: "d (info)", ttlMs: 0, inlineFull: true, description: "d" },
+    render: () => "rendered",
+  });
+  const json = JSON.stringify(res.structuredContent);
+  assert.doesNotMatch(json, /leakme/);
 });

--- a/src/utils/response-formatter.ts
+++ b/src/utils/response-formatter.ts
@@ -8,8 +8,11 @@
  * @module utils/response-formatter
  */
 
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { structured, type ResourceLinkSpec } from "mcp-server-framework";
 import { RESPONSE_ICONS } from "../config/index.js";
 import { scrubResource } from "./redact.js";
+import { tryRegisterResource, type RegisterResourceOptions } from "./resource-link.js";
 
 export type ActionType =
   | "deploy"
@@ -156,4 +159,38 @@ export function buildDeleteResult(
     },
     text: `${header}\n\n${JSON.stringify(scrubbed, null, 2)}`,
   };
+}
+
+/**
+ * Build a `CallToolResult` for a `*_info` tool: scrub once, register the
+ * scrubbed content for resource-link offload, and assemble the summary +
+ * (resourceLink | info) payload consumed by the handler's renderer.
+ *
+ * Pairs with the various `*InfoOutputSchema` shapes across `tools/schemas`.
+ */
+export function buildInfoResult<S extends object>(input: {
+  result: unknown;
+  summary: S;
+  register: {
+    ctx: { sessionId?: string | undefined };
+    name: string;
+    ttlMs: number;
+    inlineFull?: boolean | undefined;
+    description: string;
+  };
+  render: (payload: { summary: S } & ({ info: unknown } | { resourceLink: ResourceLinkSpec })) => string;
+}): CallToolResult {
+  const scrubbed = scrubResource(input.result);
+  const link = tryRegisterResource({
+    ctx: input.register.ctx,
+    category: "info",
+    name: input.register.name,
+    mimeType: "application/json",
+    content: JSON.stringify(scrubbed, null, 2),
+    ttlMs: input.register.ttlMs,
+    inlineFull: input.register.inlineFull,
+    description: input.register.description,
+  } satisfies RegisterResourceOptions);
+  const payload = link ? { summary: input.summary, resourceLink: link } : { summary: input.summary, info: scrubbed };
+  return structured(payload, { text: input.render(payload), ...(link ? { links: [link] } : {}) });
 }

--- a/src/utils/response-formatter.ts
+++ b/src/utils/response-formatter.ts
@@ -9,6 +9,7 @@
  */
 
 import { RESPONSE_ICONS } from "../config/index.js";
+import { scrubResource } from "./redact.js";
 
 export type ActionType =
   | "deploy"
@@ -116,8 +117,9 @@ export function buildApplyResult(
   };
   text: string;
 } {
+  const scrubbed = scrubResource(result);
   const header = formatActionResponse({ action, resourceType, resourceId });
-  const resource = result && typeof result === "object" ? (result as Record<string, unknown>) : undefined;
+  const resource = scrubbed && typeof scrubbed === "object" ? (scrubbed as Record<string, unknown>) : undefined;
   return {
     payload: {
       action,
@@ -125,7 +127,7 @@ export function buildApplyResult(
       resource_id: resourceId,
       ...(resource ? { resource } : {}),
     },
-    text: `${header}\n\n${JSON.stringify(result, null, 2)}`,
+    text: `${header}\n\n${JSON.stringify(scrubbed, null, 2)}`,
   };
 }
 
@@ -142,8 +144,9 @@ export function buildDeleteResult(
   payload: { action: "remove"; resource_type: string; resource_id: string; resource?: Record<string, unknown> };
   text: string;
 } {
+  const scrubbed = scrubResource(result);
   const header = formatActionResponse({ action: "remove", resourceType, resourceId });
-  const resource = result && typeof result === "object" ? (result as Record<string, unknown>) : undefined;
+  const resource = scrubbed && typeof scrubbed === "object" ? (scrubbed as Record<string, unknown>) : undefined;
   return {
     payload: {
       action: "remove",
@@ -151,6 +154,6 @@ export function buildDeleteResult(
       resource_id: resourceId,
       ...(resource ? { resource } : {}),
     },
-    text: `${header}\n\n${JSON.stringify(result, null, 2)}`,
+    text: `${header}\n\n${JSON.stringify(scrubbed, null, 2)}`,
   };
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "noEmit": false,
     "outDir": "build-test",
-    "rootDir": "src"
+    "rootDir": "src",
+    "tsBuildInfoFile": "./build-test/.tsbuildinfo"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": []
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "build-test",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Part of #160.

Secret values reach the MCP transcript (and the model provider) on far more paths than first scoped — the read tools *and* every `*_apply`/`*_delete`, across most resource types — because the shared `buildApplyResult`/`buildDeleteResult` builders never redacted and each read handler redacted ad hoc.

This makes redaction structural. A single `scrubResource()` runs inside three shared choke points, so apply/delete/info are scrubbed by default and a new tool can't reintroduce the gap:

- `buildApplyResult` / `buildDeleteResult` (write + delete)
- a new shared `buildInfoResult`, which the 10 resource `*_info` handlers now route through (read)

`scrubResource` wraps the framework's `SecretScrubber.scrubObject` (key-name + value-shape: JWT, bearer, basic-auth, AWS keys, connection strings, `key=value` blocks), gated by `KOMODO_SECRET_SCRUB_ENABLED`. Reusing it is preferable to a hand-rolled engine — it's public API and covers more secret shapes. This closes, generically: `config.environment` blocks (stack/deployment/repo), `webhook_secret`, `passkey`. A small bespoke `redactAlerterEndpoint` masks alerter webhook URLs, which have an innocuous key and no detectable value shape.

A short allowlist prevents over-redaction of non-secret fields the generic key-match would otherwise clobber: `public_key`/`attempted_public_key`/`periphery_public_key` (operator-visible by design) and the boolean flags `skip_secret_interp`/`auto_rotate_keys`.

**Scope:** structured resource config only. `container_inspect` is also scrubbed — its `Config.Env` is the resolved runtime environment, so a Variable-backed secret surfaces there as plaintext. Runtime/log output (`update_info`, `build_logs`, `*_action`, `komodo_exec`, container logs) is best-effort and deliberately left to a follow-up; the docs say so. `komodo_variable_*` is unchanged.

**Config:** `KOMODO_SECRET_SCRUB_ENABLED` (default on), `KOMODO_SECRET_SCRUB_KEYS`. `node:test` units including a false-positive gate over real resource-config shapes. Verified against a live Komodo v2.

**Self-contained against `main`.** This absorbs the exact-layer fix from #152 (its commits are the first two here), so #152 is closed in favour of this single PR.

_AI-assisted (Claude Opus 4.8), human-reviewed._
