### PR TITLE
Redact credentials from resource responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Container inspect and stack info leaked resolved credentials** — Sensitive object fields, environment assignments, Docker `Env` entries, URL userinfo, and credential-bearing query parameters are now redacted before either inline serialization or session resource registration.
+- **Inspect/info and resource mutation responses leaked resolved credentials** — Sensitive object fields, environment assignments, Docker `Env` entries, URL userinfo, and credential-bearing query parameters are now redacted before inline serialization, session resource registration, or shared apply/delete response formatting.
 
 ## [1.4.1] - Fixes tools and update dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Container inspect and stack info leaked resolved credentials** — Sensitive object fields, environment assignments, Docker `Env` entries, URL userinfo, and credential-bearing query parameters are now redacted before either inline serialization or session resource registration.
+
 ## [1.4.1] - Fixes tools and update dependencies
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Komodo MCP Server enables seamless interaction between AI assistants (like Claud
 | **Terminal** | `komodo_exec` *(target: server / container / deployment / stack_service)* |
 | **API Keys** | `komodo_user_list_api_keys`, `komodo_user_create_api_key`, `komodo_user_delete_api_key` |
 
-> **Tip:** Every tool carries `_meta.category` (one of `config`, `container`, `server`, `stack`, `deployment`, `build`, `repo`, `procedure`, `action`, `alerter`, `swarm`, `resource-sync`, `variable`, `update`, `terminal`, `user`) and a `requiredScopes` array (`komodo:read` / `komodo:operate` / `komodo:admin`), so MCP clients and gateways can filter or gate tools by category and three-tier RBAC.
+> **Tip:** Every tool carries `_meta.category` (one of `config`, `container`, `server`, `stack`, `deployment`, `build`, `repo`, `procedure`, `action`, `alerter`, `swarm`, `resource-sync`, `variable`, `update`, `terminal`, `user`) and a `requiredScopes` array (`komodo:read` / `komodo:operate` / `komodo:admin`), so MCP clients and gateways can filter or gate tools by category and three-tier RBAC. Container inspect and stack info redact credential-bearing values before returning or registering payloads.
 >
 > List/info/logs tools support **cursor pagination** via `{ cursor, page_size }` (1–100, default 50) and emit `_meta.page.next_cursor` when more items are available. `inspect`, `info`, `logs`, and `search_logs` responses also include a session-scoped `ephemeral://…` resource link so large payloads can be fetched out-of-band via `resources/read`; pass `inline_full: true` to force inlining.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Komodo MCP Server enables seamless interaction between AI assistants (like Claud
 | **Terminal** | `komodo_exec` *(target: server / container / deployment / stack_service)* |
 | **API Keys** | `komodo_user_list_api_keys`, `komodo_user_create_api_key`, `komodo_user_delete_api_key` |
 
-> **Tip:** Every tool carries `_meta.category` (one of `config`, `container`, `server`, `stack`, `deployment`, `build`, `repo`, `procedure`, `action`, `alerter`, `swarm`, `resource-sync`, `variable`, `update`, `terminal`, `user`) and a `requiredScopes` array (`komodo:read` / `komodo:operate` / `komodo:admin`), so MCP clients and gateways can filter or gate tools by category and three-tier RBAC. Container inspect and stack info redact credential-bearing values before returning or registering payloads.
+> **Tip:** Every tool carries `_meta.category` (one of `config`, `container`, `server`, `stack`, `deployment`, `build`, `repo`, `procedure`, `action`, `alerter`, `swarm`, `resource-sync`, `variable`, `update`, `terminal`, `user`) and a `requiredScopes` array (`komodo:read` / `komodo:operate` / `komodo:admin`), so MCP clients and gateways can filter or gate tools by category and three-tier RBAC. Inspect/info and apply/delete responses redact credential-bearing values before returning or registering payloads.
 >
 > List/info/logs tools support **cursor pagination** via `{ cursor, page_size }` (1–100, default 50) and emit `_meta.page.next_cursor` when more items are available. `inspect`, `info`, `logs`, and `search_logs` responses also include a session-scoped `ephemeral://…` resource link so large payloads can be fetched out-of-band via `resources/read`; pass `inline_full: true` to force inlining.
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:fix": "eslint 'src/**/*.ts' --fix",
     "format": "prettier --write 'src/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts'",
+    "test": "npm run build:prod && node --test test/*.test.mjs",
     "docker:build": "docker build --build-arg VERSION=$npm_package_version --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) --build-arg COMMIT_SHA=$(git rev-parse HEAD 2>/dev/null || echo 'unknown') -t komodo-mcp-server:$npm_package_version -t komodo-mcp-server:latest .",
     "docker:build-no-cache": "docker build --no-cache --build-arg VERSION=$npm_package_version --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) --build-arg COMMIT_SHA=$(git rev-parse HEAD 2>/dev/null || echo 'unknown') -t komodo-mcp-server:$npm_package_version -t komodo-mcp-server:latest ."
   },

--- a/src/tools/container.ts
+++ b/src/tools/container.ts
@@ -38,6 +38,7 @@ import {
   renderContainerSearchLogs,
   renderActionResult,
   tryRegisterResource,
+  redactSensitiveData,
 } from "../utils/index.js";
 import {
   containerActionInputSchema,
@@ -117,19 +118,20 @@ export const inspectContainerTool = defineTool({
       () => komodo.client.read("InspectDockerContainer", { server: args.server, container: args.container }),
       abortSignal,
     );
+    const safeResult = redactSensitiveData(result);
     const link = tryRegisterResource({
       ctx: { sessionId },
       category: "inspect",
       name: `${args.container} (inspect)`,
       mimeType: "application/json",
-      content: JSON.stringify(result, null, 2),
+      content: JSON.stringify(safeResult, null, 2),
       ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
       inlineFull: args.inline_full,
       description: `Docker inspect data for container ${args.container} on ${args.server}`,
     });
     const payload = link
       ? { summary: { name: args.container }, resourceLink: link }
-      : { summary: { name: args.container }, inspect: result };
+      : { summary: { name: args.container }, inspect: safeResult };
     return structured(payload, {
       text: renderContainerInspect(payload),
       ...(link ? { links: [link] } : {}),

--- a/src/tools/stack.ts
+++ b/src/tools/stack.ts
@@ -30,6 +30,7 @@ import {
   tryRegisterResource,
   buildApplyResult,
   buildDeleteResult,
+  redactSensitiveData,
 } from "../utils/index.js";
 import {
   stackApplyInputSchema,
@@ -97,18 +98,19 @@ export const getStackInfoTool = defineTool({
       () => komodo.client.read("GetStack", { stack: args.stack }),
       abortSignal,
     );
+    const safeResult = redactSensitiveData(result);
     const link = tryRegisterResource({
       ctx: { sessionId },
       category: "info",
       name: `${args.stack} (stack info)`,
       mimeType: "application/json",
-      content: JSON.stringify(result, null, 2),
+      content: JSON.stringify(safeResult, null, 2),
       ttlMs: config.KOMODO_RESOURCE_TTL_INFO,
       inlineFull: args.inline_full,
       description: `Full stack resource for ${args.stack}`,
     });
     const summary = { id: args.stack, name: args.stack };
-    const payload = link ? { summary, resourceLink: link } : { summary, info: result };
+    const payload = link ? { summary, resourceLink: link } : { summary, info: safeResult };
     return structured(payload, {
       text: renderStackInfo(payload),
       ...(link ? { links: [link] } : {}),

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,6 +19,9 @@ export { requireClient, checkCancelled, wrapApiCall } from "./api-helpers.js";
 export { tryRegisterResource } from "./resource-link.js";
 export type { ResourceCategory, ResourceLinkContext, RegisterResourceOptions } from "./resource-link.js";
 
+// --- Sensitive Output Redaction ---
+export { REDACTION_MARKER, redactSensitiveData } from "./redact-sensitive.js";
+
 // --- Polling ---
 export { extractUpdateId, wrapExecuteAndPoll, buildActionResult } from "./polling.js";
 export type { ActionResult } from "./polling.js";

--- a/src/utils/redact-sensitive.ts
+++ b/src/utils/redact-sensitive.ts
@@ -18,7 +18,8 @@ const SENSITIVE_KEY_PARTS = [
 
 function isSensitiveKey(key: string): boolean {
   const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
-  return SENSITIVE_KEY_PARTS.some((part) => normalized.includes(part));
+  const tokens = key.toLowerCase().split(/[^a-z0-9]+/);
+  return tokens.includes("pass") || SENSITIVE_KEY_PARTS.some((part) => normalized.includes(part));
 }
 
 function decodeKey(key: string): string {
@@ -31,9 +32,9 @@ function decodeKey(key: string): string {
 
 function redactString(input: string): string {
   const assignmentsRedacted = input.replace(
-    /(^|[\r\n])([A-Za-z_][A-Za-z0-9_.-]*)(\s*[:=]\s*)([^\r\n]*)/g,
-    (match, prefix: string, key: string, separator: string) =>
-      isSensitiveKey(key) ? `${prefix}${key}${separator}${REDACTION_MARKER}` : match,
+    /(^|[\r\n])([^\S\r\n]*)([A-Za-z_][A-Za-z0-9_.-]*)([^\S\r\n]*[:=][^\S\r\n]*)([^\r\n]*)/g,
+    (match, prefix: string, indentation: string, key: string, separator: string) =>
+      isSensitiveKey(key) ? `${prefix}${indentation}${key}${separator}${REDACTION_MARKER}` : match,
   );
 
   const userInfoRedacted = assignmentsRedacted.replace(

--- a/src/utils/redact-sensitive.ts
+++ b/src/utils/redact-sensitive.ts
@@ -1,0 +1,65 @@
+/** Stable replacement used for values removed from tool and resource output. */
+export const REDACTION_MARKER = "[REDACTED]";
+
+const SENSITIVE_KEY_PARTS = [
+  "password",
+  "passwd",
+  "passphrase",
+  "secret",
+  "token",
+  "credential",
+  "authorization",
+  "cookie",
+  "apikey",
+  "accesskey",
+  "privatekey",
+  "signingkey",
+] as const;
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return SENSITIVE_KEY_PARTS.some((part) => normalized.includes(part));
+}
+
+function decodeKey(key: string): string {
+  try {
+    return decodeURIComponent(key);
+  } catch {
+    return key;
+  }
+}
+
+function redactString(input: string): string {
+  const assignmentsRedacted = input.replace(
+    /(^|[\r\n])([A-Za-z_][A-Za-z0-9_.-]*)(\s*[:=]\s*)([^\r\n]*)/g,
+    (match, prefix: string, key: string, separator: string) =>
+      isSensitiveKey(key) ? `${prefix}${key}${separator}${REDACTION_MARKER}` : match,
+  );
+
+  const userInfoRedacted = assignmentsRedacted.replace(
+    /([a-z][a-z0-9+.-]*:\/\/[^:/\s?#]+:)([^@\s/]+)(@)/gi,
+    `$1${REDACTION_MARKER}$3`,
+  );
+
+  return userInfoRedacted.replace(/([?&])([^=&\s]+)=([^&#\s]*)/g, (match, prefix: string, key: string) =>
+    isSensitiveKey(decodeKey(key)) ? `${prefix}${key}=${REDACTION_MARKER}` : match,
+  );
+}
+
+/**
+ * Return a deep, non-mutating copy with credential-bearing values removed.
+ *
+ * This runs before inline serialization and before payloads enter the dynamic
+ * resource registry, so both MCP delivery paths receive the same safe value.
+ */
+export function redactSensitiveData(value: unknown): unknown {
+  if (typeof value === "string") return redactString(value);
+  if (Array.isArray(value)) return value.map((item) => redactSensitiveData(item));
+  if (value === null || typeof value !== "object") return value;
+
+  const output: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    output[key] = isSensitiveKey(key) ? REDACTION_MARKER : redactSensitiveData(child);
+  }
+  return output;
+}

--- a/src/utils/response-formatter.ts
+++ b/src/utils/response-formatter.ts
@@ -9,6 +9,7 @@
  */
 
 import { RESPONSE_ICONS } from "../config/index.js";
+import { redactSensitiveData } from "./redact-sensitive.js";
 
 export type ActionType =
   | "deploy"
@@ -117,7 +118,8 @@ export function buildApplyResult(
   text: string;
 } {
   const header = formatActionResponse({ action, resourceType, resourceId });
-  const resource = result && typeof result === "object" ? (result as Record<string, unknown>) : undefined;
+  const safeResult = redactSensitiveData(result);
+  const resource = safeResult && typeof safeResult === "object" ? (safeResult as Record<string, unknown>) : undefined;
   return {
     payload: {
       action,
@@ -125,7 +127,7 @@ export function buildApplyResult(
       resource_id: resourceId,
       ...(resource ? { resource } : {}),
     },
-    text: `${header}\n\n${JSON.stringify(result, null, 2)}`,
+    text: `${header}\n\n${JSON.stringify(safeResult, null, 2)}`,
   };
 }
 
@@ -143,7 +145,8 @@ export function buildDeleteResult(
   text: string;
 } {
   const header = formatActionResponse({ action: "remove", resourceType, resourceId });
-  const resource = result && typeof result === "object" ? (result as Record<string, unknown>) : undefined;
+  const safeResult = redactSensitiveData(result);
+  const resource = safeResult && typeof safeResult === "object" ? (safeResult as Record<string, unknown>) : undefined;
   return {
     payload: {
       action: "remove",
@@ -151,6 +154,6 @@ export function buildDeleteResult(
       resource_id: resourceId,
       ...(resource ? { resource } : {}),
     },
-    text: `${header}\n\n${JSON.stringify(result, null, 2)}`,
+    text: `${header}\n\n${JSON.stringify(safeResult, null, 2)}`,
   };
 }

--- a/test/redact-sensitive.test.mjs
+++ b/test/redact-sensitive.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+async function loadRedactor() {
+  try {
+    return await import("../build/utils/redact-sensitive.js");
+  } catch {
+    return {};
+  }
+}
+
+test("exports a sensitive-data redactor", async () => {
+  const { redactSensitiveData } = await loadRedactor();
+  assert.equal(typeof redactSensitiveData, "function");
+});
+
+test("redacts nested sensitive keys case-insensitively", async () => {
+  const { redactSensitiveData, REDACTION_MARKER } = await loadRedactor();
+  const input = {
+    apiSecret: "sentinel-secret",
+    nested: { PASSWORD: "sentinel-password", normal: "visible" },
+  };
+
+  assert.deepEqual(redactSensitiveData(input), {
+    apiSecret: REDACTION_MARKER,
+    nested: { PASSWORD: REDACTION_MARKER, normal: "visible" },
+  });
+});
+
+test("redacts sensitive assignments in multiline environment strings", async () => {
+  const { redactSensitiveData, REDACTION_MARKER } = await loadRedactor();
+  const input = "PUBLIC_NAME=visible\nKOMODO_API_SECRET=sentinel-secret\nACCESS_TOKEN: sentinel-token";
+
+  assert.equal(
+    redactSensitiveData(input),
+    `PUBLIC_NAME=visible\nKOMODO_API_SECRET=${REDACTION_MARKER}\nACCESS_TOKEN: ${REDACTION_MARKER}`,
+  );
+});
+
+test("redacts sensitive entries in Docker Env arrays while preserving ordinary values", async () => {
+  const { redactSensitiveData, REDACTION_MARKER } = await loadRedactor();
+  const input = { Config: { Env: ["PORT=9180", "API_KEY=sentinel-key", "DB_PASSWORD=sentinel-password"] } };
+
+  assert.deepEqual(redactSensitiveData(input), {
+    Config: { Env: ["PORT=9180", `API_KEY=${REDACTION_MARKER}`, `DB_PASSWORD=${REDACTION_MARKER}`] },
+  });
+});
+
+test("redacts URL credentials and sensitive query parameters", async () => {
+  const { redactSensitiveData, REDACTION_MARKER } = await loadRedactor();
+  const input = {
+    endpoint: "https://user:sentinel-password@example.test/hook?token=sentinel-token&view=full",
+  };
+
+  assert.deepEqual(redactSensitiveData(input), {
+    endpoint: `https://user:${REDACTION_MARKER}@example.test/hook?token=${REDACTION_MARKER}&view=full`,
+  });
+});
+
+test("preserves malformed URL query keys without throwing", async () => {
+  const { redactSensitiveData } = await loadRedactor();
+  assert.equal(redactSensitiveData("https://example.test/?%ZZ=value"), "https://example.test/?%ZZ=value");
+});

--- a/test/redact-sensitive.test.mjs
+++ b/test/redact-sensitive.test.mjs
@@ -37,6 +37,35 @@ test("redacts sensitive assignments in multiline environment strings", async () 
   );
 });
 
+test("redacts indented Compose environment assignments while preserving indentation", async () => {
+  const { redactSensitiveData, REDACTION_MARKER } = await loadRedactor();
+  const input = [
+    "services:",
+    "  vpn:",
+    "    environment:",
+    "      OPENVPN_PASSWORD: sentinel-password",
+    "      PUBLIC_NAME: visible",
+  ].join("\n");
+
+  assert.equal(
+    redactSensitiveData(input),
+    [
+      "services:",
+      "  vpn:",
+      "    environment:",
+      `      OPENVPN_PASSWORD: ${REDACTION_MARKER}`,
+      "      PUBLIC_NAME: visible",
+    ].join("\n"),
+  );
+});
+
+test("redacts common short pass assignment keys without matching pass inside ordinary words", async () => {
+  const { redactSensitiveData, REDACTION_MARKER } = await loadRedactor();
+  const input = ["PIA_PASS=sentinel-password", "COMPASS_MODE=visible"].join("\n");
+
+  assert.equal(redactSensitiveData(input), `PIA_PASS=${REDACTION_MARKER}\nCOMPASS_MODE=visible`);
+});
+
 test("redacts sensitive entries in Docker Env arrays while preserving ordinary values", async () => {
   const { redactSensitiveData, REDACTION_MARKER } = await loadRedactor();
   const input = { Config: { Env: ["PORT=9180", "API_KEY=sentinel-key", "DB_PASSWORD=sentinel-password"] } };

--- a/test/tool-redaction.test.mjs
+++ b/test/tool-redaction.test.mjs
@@ -6,6 +6,7 @@ const framework = await import("mcp-server-framework");
 const { komodoConnection } = await import("../build/client.js");
 const { inspectContainerTool } = await import("../build/tools/container.js");
 const { getStackInfoTool } = await import("../build/tools/stack.js");
+const { buildApplyResult, buildDeleteResult } = await import("../build/utils/response-formatter.js");
 
 const sentinel = "sentinel-never-return";
 const signal = new AbortController().signal;
@@ -64,3 +65,15 @@ test("stack info redacts both inline and resource-link payloads", async () => {
   assert.match(resource.content, /\[REDACTED\]/);
 });
 
+test("shared apply and delete responses redact returned resource snapshots", () => {
+  const resource = { config: { environment: `API_SECRET=${sentinel}\nPUBLIC_NAME=visible` } };
+  for (const built of [
+    buildApplyResult("create", "stack", "stack", resource),
+    buildDeleteResult("stack", "stack", resource),
+  ]) {
+    const output = JSON.stringify(built);
+    assert.doesNotMatch(output, new RegExp(sentinel));
+    assert.match(output, /\[REDACTED\]/);
+    assert.match(output, /PUBLIC_NAME=visible/);
+  }
+});

--- a/test/tool-redaction.test.mjs
+++ b/test/tool-redaction.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+await import("../build/utils/polyfills.js");
+const framework = await import("mcp-server-framework");
+const { komodoConnection } = await import("../build/client.js");
+const { inspectContainerTool } = await import("../build/tools/container.js");
+const { getStackInfoTool } = await import("../build/tools/stack.js");
+
+const sentinel = "sentinel-never-return";
+const signal = new AbortController().signal;
+
+function fakeClient(result) {
+  return { client: { read: async () => structuredClone(result) } };
+}
+
+test("container inspect redacts both inline and resource-link payloads", async () => {
+  komodoConnection.getClient = () =>
+    fakeClient({ Config: { Env: [`API_KEY=${sentinel}`, "PORT=9180"] }, Name: "safe-name" });
+
+  const inline = await inspectContainerTool.handler(
+    { server: "server", container: "container", inline_full: true },
+    { abortSignal: signal },
+  );
+  const inlineJson = JSON.stringify(inline.structuredContent);
+  assert.doesNotMatch(inlineJson, new RegExp(sentinel));
+  assert.match(inlineJson, /\[REDACTED\]/);
+
+  framework.resetDynamicResourceRegistry();
+  framework.configureDynamicResourceRegistry({ uriScheme: "ephemeral", maxEntries: 10 });
+  const linked = await inspectContainerTool.handler(
+    { server: "server", container: "container" },
+    { abortSignal: signal, sessionId: "redaction-test" },
+  );
+  const resource = await framework
+    .getDynamicResourceRegistry()
+    .read(linked.structuredContent.resourceLink.uri, "redaction-test");
+  assert.doesNotMatch(resource.content, new RegExp(sentinel));
+  assert.match(resource.content, /\[REDACTED\]/);
+});
+
+test("stack info redacts both inline and resource-link payloads", async () => {
+  komodoConnection.getClient = () =>
+    fakeClient({ config: { environment: `PORT=9180\nKOMODO_API_SECRET=${sentinel}` }, name: "safe-stack" });
+
+  const inline = await getStackInfoTool.handler(
+    { stack: "stack", inline_full: true },
+    { abortSignal: signal },
+  );
+  const inlineJson = JSON.stringify(inline.structuredContent);
+  assert.doesNotMatch(inlineJson, new RegExp(sentinel));
+  assert.match(inlineJson, /\[REDACTED\]/);
+
+  framework.resetDynamicResourceRegistry();
+  framework.configureDynamicResourceRegistry({ uriScheme: "ephemeral", maxEntries: 10 });
+  const linked = await getStackInfoTool.handler(
+    { stack: "stack" },
+    { abortSignal: signal, sessionId: "redaction-test" },
+  );
+  const resource = await framework
+    .getDynamicResourceRegistry()
+    .read(linked.structuredContent.resourceLink.uri, "redaction-test");
+  assert.doesNotMatch(resource.content, new RegExp(sentinel));
+  assert.match(resource.content, /\[REDACTED\]/);
+});
+

--- a/test/tool-redaction.test.mjs
+++ b/test/tool-redaction.test.mjs
@@ -65,6 +65,46 @@ test("stack info redacts both inline and resource-link payloads", async () => {
   assert.match(resource.content, /\[REDACTED\]/);
 });
 
+test("stack info redacts indented Compose and short pass environment secrets", async () => {
+  const indentedSentinel = "sentinel-indented-compose-password";
+  const shortPassSentinel = "sentinel-short-pass-password";
+  komodoConnection.getClient = () =>
+    fakeClient({
+      config: {
+        file_contents: [
+          "services:",
+          "  vpn:",
+          "    environment:",
+          `      OPENVPN_PASSWORD: ${indentedSentinel}`,
+          "      PUBLIC_NAME: visible",
+          `      PIA_PASS=${shortPassSentinel}`,
+          "      COMPASS_MODE=visible",
+        ].join("\n"),
+      },
+      name: "safe-stack",
+    });
+
+  const inline = await getStackInfoTool.handler({ stack: "stack", inline_full: true }, { abortSignal: signal });
+  const inlineJson = JSON.stringify(inline.structuredContent);
+  assert.doesNotMatch(inlineJson, new RegExp(indentedSentinel));
+  assert.doesNotMatch(inlineJson, new RegExp(shortPassSentinel));
+  assert.match(inlineJson, /\[REDACTED\]/);
+  assert.match(inlineJson, /PUBLIC_NAME: visible/);
+  assert.match(inlineJson, /COMPASS_MODE=visible/);
+
+  framework.resetDynamicResourceRegistry();
+  framework.configureDynamicResourceRegistry({ uriScheme: "ephemeral", maxEntries: 10 });
+  const linked = await getStackInfoTool.handler({ stack: "stack" }, { abortSignal: signal, sessionId: "redaction-test" });
+  const resource = await framework
+    .getDynamicResourceRegistry()
+    .read(linked.structuredContent.resourceLink.uri, "redaction-test");
+  assert.doesNotMatch(resource.content, new RegExp(indentedSentinel));
+  assert.doesNotMatch(resource.content, new RegExp(shortPassSentinel));
+  assert.match(resource.content, /\[REDACTED\]/);
+  assert.match(resource.content, /PUBLIC_NAME: visible/);
+  assert.match(resource.content, /COMPASS_MODE=visible/);
+});
+
 test("shared apply and delete responses redact returned resource snapshots", () => {
   const resource = { config: { environment: `API_SECRET=${sentinel}\nPUBLIC_NAME=visible` } };
   for (const built of [


### PR DESCRIPTION
## What changed

- redact credential-bearing object keys recursively
- redact sensitive environment assignments, Docker `Env` entries, URL userinfo, and sensitive query parameters
- sanitize before inline serialization, ephemeral resource registration, and shared apply/delete response formatting
- add Node test coverage for the redactor and both tool delivery paths

## Why

`komodo_container_inspect`, `komodo_stack_info`, and shared apply/delete responses returned raw Komodo/Docker payloads. Those payloads can contain resolved environment credentials, and session resource offload stored the same raw values. Read and mutation tools could therefore place production credentials directly into an AI client's context.

The root cause was that raw API results were serialized or registered without a sanitization boundary.

## Impact

Ordinary fields remain visible. Credential-bearing values are replaced with a stable `[REDACTED]` marker whether callers use normal session resources, stateless inline fallback, or `inline_full: true`.

## Validation

- `npm test` — 9 passing, including inline, resource-link, apply, and delete sentinel regression tests
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `git diff --check`
